### PR TITLE
Corrected issue where Firefox wasn't displaying StopTimesList table correctly.

### DIFF
--- a/src/ui/HelpPage.tsx
+++ b/src/ui/HelpPage.tsx
@@ -7,7 +7,6 @@ public render() {
   return (
     <div>
       <h1>Virtuaalimonitorin käyttöopas</h1>
-        <h2>Käytä Chromea parhaan käyttökokemuksen takaamiseksi!</h2>
         <h2>Virtuaalimonitorin käyttö selainparametrien avulla </h2>
        <p>
          Pysäkkinäytön käyttö selaimen osoiteriviltä tapahtuu seuraavasti: kirjoita osoitteen perään /stop/pysäkit/rivimäärä. Esimerkiksi /stop/tampere:0010/10 näyttää 10 riviä pysäkiltä Keskustori F. 

--- a/src/ui/Views/StopTimesView.css
+++ b/src/ui/Views/StopTimesView.css
@@ -1,6 +1,7 @@
 .StopTimesList {
   /* border-collapse: collapse; */
   border-spacing: 0;
+  width: 100%
 }
 
 .StopTimesList thead {


### PR DESCRIPTION
Added width 100% to fix issue with firefox for showing StopTimesList table.