### PR TITLE
fix: duplicate on stop views

### DIFF
--- a/src/ui/Views/StopTimesView.tsx
+++ b/src/ui/Views/StopTimesView.tsx
@@ -84,7 +84,7 @@ const duplicatePruneMethods: {
     return stopsTimes
       .reduce(
         (acc: IStopTime[], curr: IStopTime) => {
-          const foundDuplicate = acc.find(stopTime => (stopTime.trip && curr.trip && stopTime.trip.gtfsId === curr.trip.gtfsId));
+          const foundDuplicate = acc.find(stopTime => (stopTime.trip && curr.trip && stopTime.stop.gtfsId === curr.stop.gtfsId && stopTime.trip.gtfsId === curr.trip.gtfsId));
           if (foundDuplicate) {
             // Found a duplicate.
             if (foundDuplicate.usedTime - curr.usedTime >= duplicateRouteTimeThresholdSeconds) {


### PR DESCRIPTION
Torikulma I Tupatie E was "hide" because wrong check. Now these two different examples should return same stop times.
stop/MATKA:7_201848,MATKA:7_201860/10
stop/MATKA:7_201860,MATKA:7_201848/10