### PR TITLE
DT-4852: Fixes for multilanguage titles

### DIFF
--- a/src/ui/StopListTitleInput.tsx
+++ b/src/ui/StopListTitleInput.tsx
@@ -78,6 +78,7 @@ function StopListTitleInput(props: {
           setChangedRight(true);
         }
       }
+      event.preventDefault();
       return false;
     }
 

--- a/src/ui/StopViewTitleEditor.scss
+++ b/src/ui/StopViewTitleEditor.scss
@@ -11,6 +11,11 @@
   display: flex;
 
   .stop-title-input {
+    &.east-west {
+      &:focus {
+        outline: none;
+      }
+    }
     font-size: 21px;
     font-style: normal;
     font-weight: 400;

--- a/src/ui/StopViewTitleEditor.tsx
+++ b/src/ui/StopViewTitleEditor.tsx
@@ -1,3 +1,4 @@
+import cx from 'classnames';
 import React, { FC, useState } from 'react';
 import './StopViewTitleEditor.scss';
 import { ITitle } from '../util/Interfaces';
@@ -121,7 +122,7 @@ const StopViewTitleEditor: FC<IProps & WithTranslation> = ({
         )}
         {getLayout(layout)[2] && (
           <input
-            className="stop-title-input"
+            className={cx('stop-title-input', 'east-west')}
             id={`stop-title-input${id}-${lang}`}
             value={layoutTitle}
             readOnly


### PR DESCRIPTION
input fields no longer put double char in start. Removed focus outlin…e from East west layout title
v.0.2.4l.5.1.1.beta.alpha