### PR TITLE
DT-5008: Handle alert's with only header

### DIFF
--- a/src/api.tsx
+++ b/src/api.tsx
@@ -22,11 +22,11 @@ const monitorAPI = {
           accepts: 'application/json',
         },
       })
-      .then(result => result.json())
-      .then(json => resolve(json))
-      .catch(err => {
-        reject(err);
-      });
+        .then(result => result.json())
+        .then(json => resolve(json))
+        .catch(err => {
+          reject(err);
+        });
     });
   },
   getMonitorsForUser(urls) {

--- a/src/ui/MonitorAlertRow.tsx
+++ b/src/ui/MonitorAlertRow.tsx
@@ -1,5 +1,9 @@
 import React, { FC, useEffect, useState } from 'react';
 import cx from 'classnames';
+import {
+  getServiceAlertDescription,
+  getServiceAlertHeader,
+} from '../util/alertUtils';
 
 interface IProps {
   alerts: any;
@@ -60,20 +64,34 @@ const MonitorAlertRow: FC<IProps> = ({
 
   const a = [];
   for (let i = 0; i < alerts.length; i++) {
-    for (let j = 0; j < languages.length; j++) {
+    if (
+      alerts[i].alertDescriptionTextTranslations ||
+      alerts[i].alertHeaderTextTranslations
+    ) {
+      for (let j = 0; j < languages.length; j++) {
+        a.push(
+          <span key={`alert-${i + 1}-lang-${j + 1}`} className="single-alert">
+            {getServiceAlertDescription(alerts[i], languages[j]) ||
+              getServiceAlertHeader(alerts[i], languages[j])}
+          </span>,
+        );
+      }
+    } else {
       a.push(
-        <span key={`alert-${i + 1}-lang-${j + 1}`} className="single-alert">
-          {
-            alerts[i].alertDescriptionTextTranslations.find(
-              a => a.language === languages[j],
-            ).text
-          }
+        <span key={`alert-${i + 1}-lang-1`} className="single-alert">
+          {getServiceAlertDescription(alerts[i], 'fi') ||
+            getServiceAlertHeader(alerts[i], 'fi')}
         </span>,
       );
     }
-    a.push(
-      <div key={`alert-${i + 1}-separator}`} className="alert-separator"></div>,
-    );
+    if (!(i === alerts.length - 1) && !(alertOrientation === 'horizontal')) {
+      a.push(
+        <div
+          key={`alert-${i + 1}-separator}`}
+          className="alert-separator"
+        ></div>,
+      );
+    }
   }
   const style = {
     '--animationWidth': `${Number(-1 * animationWidth).toFixed(0)}px`,

--- a/src/ui/MonitorAlertRowStatic.tsx
+++ b/src/ui/MonitorAlertRowStatic.tsx
@@ -1,5 +1,9 @@
 import React, { FC, useEffect, useState } from 'react';
 import cx from 'classnames';
+import {
+  getServiceAlertDescription,
+  getServiceAlertHeader,
+} from '../util/alertUtils';
 
 interface IProps {
   alerts: any;
@@ -17,11 +21,17 @@ const MonitorAlertRowStatic: FC<IProps> = ({ alerts, languages }) => {
     }, 5000);
     return () => clearTimeout(id);
   }, [current]);
-  const alert = alerts[
-    current % alerts.length
-  ].alertDescriptionTextTranslations.find(
-    a => a.language === languages[current % languages.length],
-  ).text;
+
+  const alert =
+    getServiceAlertDescription(
+      alerts[current % alerts.length],
+      languages[current % languages.length],
+    ) ||
+    getServiceAlertHeader(
+      alerts[current % alerts.length],
+      languages[current % languages.length],
+    );
+
   return (
     <div className={cx('grid-row', 'alert static')}>
       <div className={cx('grid-cols', 'alert-row')}>{alert}</div>

--- a/src/util/alertUtils.ts
+++ b/src/util/alertUtils.ts
@@ -1,0 +1,36 @@
+const getTranslation = (translations, defaultValue, locale) => {
+  if (!Array.isArray(translations)) {
+    return defaultValue;
+  }
+  const translation =
+    translations.find(t => t.language === locale) ||
+    translations.find(t => !t.language && t.text) ||
+    translations.find(t => t.language === 'en');
+  return translation ? translation.text : defaultValue;
+};
+
+/**
+ * Attempts to find the alert's header in the given language.
+ *
+ * @param {*} alert the alert object to look into.
+ * @param {*} locale the locale to use, defaults to 'en'.
+ */
+export const getServiceAlertHeader = (alert, locale = 'en') =>
+  getTranslation(
+    alert.alertHeaderTextTranslations,
+    alert.alertHeaderText || '',
+    locale,
+  );
+
+/**
+ * Attempts to find the alert's description in the given language.
+ *
+ * @param {*} alert the alert object to look into.
+ * @param {*} locale the locale to use, defaults to 'en'.
+ */
+export const getServiceAlertDescription = (alert, locale = 'en') =>
+  getTranslation(
+    alert.alertDescriptionTextTranslations,
+    alert.alertDescriptionText || '',
+    locale,
+  );


### PR DESCRIPTION
- use text field if no translations are available
- use header if no description is available