### PR TITLE
DT-5133: [MINOR] Remove POC login from production environment

### DIFF
--- a/src/LandingPage.tsx
+++ b/src/LandingPage.tsx
@@ -14,7 +14,8 @@ const LandingPage: React.FC<IProps> = props => {
     urls: ['abcdef', 'ghijk'],
   };
   // ----------                                 ----------
-  const logIn = user.loggedIn && user.urls.length > 0;
+  const logIn =
+    user.loggedIn && user.urls.length > 0 && props.config.allowLogin;
   return (
     <>
       <section aria-label="navigation">

--- a/src/monitorConfig.js
+++ b/src/monitorConfig.js
@@ -26,6 +26,7 @@ export default {
     showMinutes: '10',
     alertOrientation: 'horizontal', // Possible values are 'vertical', 'horizontal' and 'static'
     breadCrumbsStartPage: 'front', // Possible values are 'front' and 'site'
+    allowLogin: false,
   },
   jyvaskyla: {
     colors: {
@@ -45,6 +46,7 @@ export default {
     showMinutes: '10',
     alertOrientation: 'horizontal', // Possible values are 'vertical', 'horizontal' and 'static'
     breadCrumbsStartPage: 'front', // Possible values are 'front' and 'site'
+    allowLogin: false,
   },
   matka: {
     colors: {
@@ -69,6 +71,7 @@ export default {
     showMinutes: '15',
     alertOrientation: 'horizontal', // Possible values are 'vertical', 'horizontal' and 'static'
     breadCrumbsStartPage: 'front', // Possible values are 'front' and 'site'
+    allowLogin: false,
   },
   tampere: {
     colors: {
@@ -90,5 +93,6 @@ export default {
     showMinutes: '20',
     alertOrientation: 'horizontal', // Possible values are 'vertical', 'horizontal' and 'static'
     breadCrumbsStartPage: 'front', // Possible values are 'front' and 'site'
+    allowLogin: false,
   },
 };

--- a/src/util/getConfig.tsx
+++ b/src/util/getConfig.tsx
@@ -38,7 +38,6 @@ const defaultFonts: IExtendedMonitorConfig = {
 export const getConfig = () => {
   // When developing locally, you can define REACT_APP_CONFIG env variable. Use themes assinged below.
   const env = process.env.REACT_APP_CONFIG;
-  // console.log('ENV:', process.env);
   const allowedThemes = ['hsl', 'matka', 'tampere', 'jyvaskyla'];
   if (env && allowedThemes.indexOf(env) > -1) {
     return config[env];


### PR DESCRIPTION
Instead of removing login for now in prod, added allowLogin param to configuration.