### PR TITLE
DT-5134: Breadcrumb shows login texts even if login is disabled from config

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -60,6 +60,8 @@ export interface IExtendedMonitorConfig extends IMonitorConfig {
     postfix?: string;
     setName?: string;
   };
+  allowLogin?: boolean;
+
 }
 export interface IMonitorConfig {
   name?: string;
@@ -198,7 +200,7 @@ const App: React.FC<combinedConfigurationAndInjected & WithTranslation> = (
                 <section aria-label="navigation">
                   <Banner config={monitorConfig} />
                   <Breadcrumbs
-                    isLogged={user.loggedIn}
+                    isLogged={user.loggedIn && monitorConfig.allowLogin}
                     start={monitorConfig.breadCrumbsStartPage}
                   />
                 </section>

--- a/src/LandingPage.tsx
+++ b/src/LandingPage.tsx
@@ -21,7 +21,7 @@ const LandingPage: React.FC<IProps> = props => {
       <section aria-label="navigation">
         <Banner config={props.config} user={user} />
         <Breadcrumbs
-          isLogged={user.loggedIn}
+          isLogged={user.loggedIn &&  props.config.allowLogin }
           start={props.config.breadCrumbsStartPage}
         />
       </section>

--- a/src/ui/Breadcrumbs.tsx
+++ b/src/ui/Breadcrumbs.tsx
@@ -16,7 +16,6 @@ const Breadcrumbs: FC<IProps & WithTranslation> = ({ isLogged, start, t }) => {
   const isModify =
     arr.length > 2 || window.location.href.indexOf('cont=') !== -1;
   let crumb;
-
   switch (path) {
     case 'createview':
     case 'createstaticview':


### PR DESCRIPTION
fixed an issue where breadcrumb would show login texts even if login is disabled via config