### PR TITLE
DT-5138: Modify no monitors found -view (mouse moving show etc.) [MINOR]

### DIFF
--- a/src/ui/CreateViewPage.tsx
+++ b/src/ui/CreateViewPage.tsx
@@ -39,10 +39,7 @@ const CreateViewPage: React.FC<IProps & WithTranslation> = props => {
 
   const hash: any = location.search.split('cont=');
 
-  if (hash[1] && !stopCardList) {
-    return null;
-  }
-  if (!hash[1]) {
+  if (!hash[1] || (hash[1] && !stopCardList)) {
     return (
       <ContentContainer>
         <StopCardListContainer

--- a/src/ui/MonitorOverlay.tsx
+++ b/src/ui/MonitorOverlay.tsx
@@ -9,6 +9,8 @@ interface IProps {
   staticContentHash?: string;
   staticUrl?: string;
   staticViewTitle?: string;
+  buttonTranslationKey?: string;
+  createNew?: boolean;
 }
 const MonitorOverlay: FC<IProps & WithTranslation> = ({
   isPreview,
@@ -16,21 +18,22 @@ const MonitorOverlay: FC<IProps & WithTranslation> = ({
   staticUrl,
   staticViewTitle,
   staticContentHash,
+  buttonTranslationKey,
+  createNew,
   t,
 }) => {
+  const text = t(buttonTranslationKey) || t('edit-display');
+  const to = createNew
+    ? '/createView'
+    : !staticUrl
+    ? `/createView${window.location.search}`
+    : `/createStaticView?name=${staticViewTitle}&url=${staticUrl}&cont=${staticContentHash}`;
   return (
     <>
       {!isPreview && (
         <div className={cx('monitor-overlay', show ? 'show' : 'hide')}>
-          <Link
-            className="link"
-            to={
-              !staticUrl
-                ? `/createView${window.location.search}`
-                : `/createStaticView?name=${staticViewTitle}&url=${staticUrl}&cont=${staticContentHash}`
-            }
-          >
-            <span>{t('edit-display')}</span>
+          <Link className="link" to={to}>
+            <span>{text}</span>
           </Link>
         </div>
       )}

--- a/src/ui/NoMonitorsFound.tsx
+++ b/src/ui/NoMonitorsFound.tsx
@@ -1,19 +1,32 @@
-import React, { FC } from 'react';
+import React, { FC, useEffect, useState } from 'react';
 import { withTranslation, WithTranslation } from 'react-i18next';
+import MonitorOverlay from './MonitorOverlay';
 
 interface IProps {
   white?: boolean;
   isPreview?: boolean;
 }
-const NoMonitorsFound: FC<IProps & WithTranslation> = props => (
-  <div className="not-found">
-    <span> {props.t('noMonitors')} </span>
-    <a href={'/createview'}>
-      <button className={'to-create-view'}>
-        {props.t('quickDisplayCreate')}
-      </button>
-    </a>
-  </div>
-);
+const NoMonitorsFound: FC<IProps & WithTranslation> = props => {
+  const [showOverlay, setShowOverlay] = useState(false);
 
+  let to;
+  return (
+    <div
+      className="not-found"
+      onMouseMove={() => {
+        setShowOverlay(true);
+        clearTimeout(to);
+        to = setTimeout(() => setShowOverlay(false), 3000);
+      }}
+    >
+      <MonitorOverlay
+        show={showOverlay}
+        createNew
+        isPreview={false}
+        buttonTranslationKey={'quickDisplayCreate'}
+      />
+      <span> {props.t('noMonitors')} </span>
+    </div>
+  );
+};
 export default withTranslation('translations')(NoMonitorsFound);


### PR DESCRIPTION
* Overlay button to monitor not found page
* If user navigates to createView page with invalid contentHash, default create view page is shown instead of empty page