### PR TITLE
DT-5285: Trains for tampere, and adjustment of StopRouteModal

### DIFF
--- a/src/monitorConfig.js
+++ b/src/monitorConfig.js
@@ -84,7 +84,7 @@ export default {
       primary: '#1c57cf',
       monitorBackground: '#1c57cf',
     },
-    feedIds: ['tampere'],
+    feedIds: ['tampere', 'TampereVR', 'tampereDRT'],
     fonts: {
       monitor: {
         name: 'Lato',

--- a/src/ui/StopRoutesModal.scss
+++ b/src/ui/StopRoutesModal.scss
@@ -102,7 +102,7 @@
           font-size: 18px;
           line-height: 22px;
           color: #333;
-          min-width: 60px;
+          min-width: 85px;
         }
 
         .destination {


### PR DESCRIPTION
* Added correct feed id's so now you can use stop monitors for trains in Tampere.
* Adjusted stop route Modal so that text aligns nicely with HDM 123 trains.

Before:
![image](https://user-images.githubusercontent.com/12114661/154479113-379b0cbd-acc4-410c-aab4-113550c54fde.png)

After:
![image](https://user-images.githubusercontent.com/12114661/154479179-f8c0014d-d077-4965-b25c-5098ed9d5c8d.png)
