### PR TITLE
DT-5321: Simplify renaming in stop settings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "@habx/apollo-multi-endpoint-link": "^2.5.0",
         "@react-aria/checkbox": "^3.2.3",
         "@react-aria/focus": "^3.5.0",
-        "@react-aria/visually-hidden": "^3.2.3",
         "@react-stately/toggle": "^3.2.3",
         "@types/graphql": "^14.5.0",
         "@typescript-eslint/eslint-plugin": "^4.22.1",
@@ -3169,86 +3168,6 @@
       }
     },
     "node_modules/@react-aria/focus/node_modules/@react-types/shared": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.10.1.tgz",
-      "integrity": "sha512-U3dLJtstvOiZ8XLrWdNv9WXuruoDyfIfSXguTs9N0naDdO+M0MIbt/1Hg7Toe43ueAe56GM14IFL+S0/jhv8ow==",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1"
-      }
-    },
-    "node_modules/@react-aria/visually-hidden": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/@react-aria/visually-hidden/-/visually-hidden-3.2.3.tgz",
-      "integrity": "sha512-iAe5EFI7obEOwTnIdAwWrKq+CrIJFGTw85v8fXnQ7CIVGRDblX85GOUww9bzQNPDLLRYWS4VF702ii8kV4+JCw==",
-      "dependencies": {
-        "@babel/runtime": "^7.6.2",
-        "@react-aria/interactions": "^3.5.1",
-        "@react-aria/utils": "^3.8.2",
-        "clsx": "^1.1.1"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1"
-      }
-    },
-    "node_modules/@react-aria/visually-hidden/node_modules/@react-aria/interactions": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@react-aria/interactions/-/interactions-3.7.0.tgz",
-      "integrity": "sha512-Xomchjb9bqvh3ocil+QCEYFSxsTy8PHEz43mNP6z2yuu3UqTpl2FsWfyKgF/Yy0WKVkyV2dO2uz758KJTCLZhw==",
-      "dependencies": {
-        "@babel/runtime": "^7.6.2",
-        "@react-aria/utils": "^3.10.0",
-        "@react-types/shared": "^3.10.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1"
-      }
-    },
-    "node_modules/@react-aria/visually-hidden/node_modules/@react-aria/interactions/node_modules/@react-types/shared": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.10.1.tgz",
-      "integrity": "sha512-U3dLJtstvOiZ8XLrWdNv9WXuruoDyfIfSXguTs9N0naDdO+M0MIbt/1Hg7Toe43ueAe56GM14IFL+S0/jhv8ow==",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1"
-      }
-    },
-    "node_modules/@react-aria/visually-hidden/node_modules/@react-aria/utils": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/@react-aria/utils/-/utils-3.11.0.tgz",
-      "integrity": "sha512-4yFA8E9xqDCUlolYSsoyp/qxrkiQrnEqx1BQOrKDuicpW7MBJ39pJC23YFMpyK2a6xEptc6xJEeIEFJXp57jJw==",
-      "dependencies": {
-        "@babel/runtime": "^7.6.2",
-        "@react-aria/ssr": "^3.1.0",
-        "@react-stately/utils": "^3.3.0",
-        "@react-types/shared": "^3.10.1",
-        "clsx": "^1.1.1"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1"
-      }
-    },
-    "node_modules/@react-aria/visually-hidden/node_modules/@react-aria/utils/node_modules/@react-aria/ssr": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.1.0.tgz",
-      "integrity": "sha512-RxqQKmE8sO7TGdrcSlHTcVzMP450hqowtBSd2bBS9oPlcokVkaGq28c3Rwa8ty5ctw4EBCjXqjP7xdcKMGDzug==",
-      "dependencies": {
-        "@babel/runtime": "^7.6.2"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1"
-      }
-    },
-    "node_modules/@react-aria/visually-hidden/node_modules/@react-aria/utils/node_modules/@react-stately/utils": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@react-stately/utils/-/utils-3.3.0.tgz",
-      "integrity": "sha512-f//Y8q0+FFcS04xvCNvbba7WWRLHzj2AegLgdgwTxsnk9Gb+AyuasdRrRY7bGQhdHuEJ7OIiQZ9EQWndDbrTcg==",
-      "dependencies": {
-        "@babel/runtime": "^7.6.2"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1"
-      }
-    },
-    "node_modules/@react-aria/visually-hidden/node_modules/@react-aria/utils/node_modules/@react-types/shared": {
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.10.1.tgz",
       "integrity": "sha512-U3dLJtstvOiZ8XLrWdNv9WXuruoDyfIfSXguTs9N0naDdO+M0MIbt/1Hg7Toe43ueAe56GM14IFL+S0/jhv8ow==",
@@ -27070,73 +26989,6 @@
           "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.10.1.tgz",
           "integrity": "sha512-U3dLJtstvOiZ8XLrWdNv9WXuruoDyfIfSXguTs9N0naDdO+M0MIbt/1Hg7Toe43ueAe56GM14IFL+S0/jhv8ow==",
           "requires": {}
-        }
-      }
-    },
-    "@react-aria/visually-hidden": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/@react-aria/visually-hidden/-/visually-hidden-3.2.3.tgz",
-      "integrity": "sha512-iAe5EFI7obEOwTnIdAwWrKq+CrIJFGTw85v8fXnQ7CIVGRDblX85GOUww9bzQNPDLLRYWS4VF702ii8kV4+JCw==",
-      "requires": {
-        "@babel/runtime": "^7.6.2",
-        "@react-aria/interactions": "^3.5.1",
-        "@react-aria/utils": "^3.8.2",
-        "clsx": "^1.1.1"
-      },
-      "dependencies": {
-        "@react-aria/interactions": {
-          "version": "3.7.0",
-          "resolved": "https://registry.npmjs.org/@react-aria/interactions/-/interactions-3.7.0.tgz",
-          "integrity": "sha512-Xomchjb9bqvh3ocil+QCEYFSxsTy8PHEz43mNP6z2yuu3UqTpl2FsWfyKgF/Yy0WKVkyV2dO2uz758KJTCLZhw==",
-          "requires": {
-            "@babel/runtime": "^7.6.2",
-            "@react-aria/utils": "^3.10.0",
-            "@react-types/shared": "^3.10.0"
-          },
-          "dependencies": {
-            "@react-types/shared": {
-              "version": "3.10.1",
-              "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.10.1.tgz",
-              "integrity": "sha512-U3dLJtstvOiZ8XLrWdNv9WXuruoDyfIfSXguTs9N0naDdO+M0MIbt/1Hg7Toe43ueAe56GM14IFL+S0/jhv8ow==",
-              "requires": {}
-            }
-          }
-        },
-        "@react-aria/utils": {
-          "version": "3.11.0",
-          "resolved": "https://registry.npmjs.org/@react-aria/utils/-/utils-3.11.0.tgz",
-          "integrity": "sha512-4yFA8E9xqDCUlolYSsoyp/qxrkiQrnEqx1BQOrKDuicpW7MBJ39pJC23YFMpyK2a6xEptc6xJEeIEFJXp57jJw==",
-          "requires": {
-            "@babel/runtime": "^7.6.2",
-            "@react-aria/ssr": "^3.1.0",
-            "@react-stately/utils": "^3.3.0",
-            "@react-types/shared": "^3.10.1",
-            "clsx": "^1.1.1"
-          },
-          "dependencies": {
-            "@react-aria/ssr": {
-              "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.1.0.tgz",
-              "integrity": "sha512-RxqQKmE8sO7TGdrcSlHTcVzMP450hqowtBSd2bBS9oPlcokVkaGq28c3Rwa8ty5ctw4EBCjXqjP7xdcKMGDzug==",
-              "requires": {
-                "@babel/runtime": "^7.6.2"
-              }
-            },
-            "@react-stately/utils": {
-              "version": "3.3.0",
-              "resolved": "https://registry.npmjs.org/@react-stately/utils/-/utils-3.3.0.tgz",
-              "integrity": "sha512-f//Y8q0+FFcS04xvCNvbba7WWRLHzj2AegLgdgwTxsnk9Gb+AyuasdRrRY7bGQhdHuEJ7OIiQZ9EQWndDbrTcg==",
-              "requires": {
-                "@babel/runtime": "^7.6.2"
-              }
-            },
-            "@react-types/shared": {
-              "version": "3.10.1",
-              "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.10.1.tgz",
-              "integrity": "sha512-U3dLJtstvOiZ8XLrWdNv9WXuruoDyfIfSXguTs9N0naDdO+M0MIbt/1Hg7Toe43ueAe56GM14IFL+S0/jhv8ow==",
-              "requires": {}
-            }
-          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "@habx/apollo-multi-endpoint-link": "^2.5.0",
     "@react-aria/checkbox": "^3.2.3",
     "@react-aria/focus": "^3.5.0",
-    "@react-aria/visually-hidden": "^3.2.3",
     "@react-stately/toggle": "^3.2.3",
     "@types/graphql": "^14.5.0",
     "@typescript-eslint/eslint-plugin": "^4.22.1",

--- a/src/App.scss
+++ b/src/App.scss
@@ -13,6 +13,17 @@ $monitor-font: var(--monitor-font);
 $monitor-font-weight: var(--monitor-font-weight);
 $monitor-font-weight-bigger: var(--monitor-font-weight-bigger);
 
+.check-box {
+  input[type=checkbox] {
+    height: 20px;
+    left: 0;
+    position: absolute;
+    top: 0;
+    visibility: hidden;
+    width: 20px;
+  }
+}
+
 ul,
 li {
   list-style-type: none;

--- a/src/test/data/monitor.ts
+++ b/src/test/data/monitor.ts
@@ -8,6 +8,9 @@ export const stop: IStop = {
 };
 
 export const departure: IDeparture = {
+  showStopNumber: false,
+  showVia: false,
+  vehicleMode: '',
   combinedPattern: 'MATKA:60061713:87:Jyväskylä:',
   headsign: 'JYVÄSKYLÄ',
   pickupType: 'SCHEDULED',
@@ -22,5 +25,5 @@ export const departure: IDeparture = {
     gtfsId: 'HSL:1234trip',
     stops: [stop],
     route: { alerts: [], shortName: '123' },
-  },
+  }
 };

--- a/src/test/data/monitor.ts
+++ b/src/test/data/monitor.ts
@@ -25,5 +25,5 @@ export const departure: IDeparture = {
     gtfsId: 'HSL:1234trip',
     stops: [stop],
     route: { alerts: [], shortName: '123' },
-  }
+  },
 };

--- a/src/ui/CheckBox.tsx
+++ b/src/ui/CheckBox.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import { useCheckbox } from '@react-aria/checkbox';
 import { useToggleState } from '@react-stately/toggle';
-
-import { VisuallyHidden } from '@react-aria/visually-hidden';
 import { useFocusRing } from '@react-aria/focus';
-
 import Icon from './Icon';
 
 function Checkbox(props) {
@@ -17,10 +14,11 @@ function Checkbox(props) {
     isFocusVisible ? '-focus' : ''
   }`;
   return (
-    <label style={{ display: 'flex', alignItems: 'center' }}>
-      <VisuallyHidden>
-        <input {...inputProps} {...focusProps} ref={ref} />
-      </VisuallyHidden>
+    <label
+      className="check-box"
+      style={{ display: 'flex', alignItems: 'center' }}
+    >
+      <input {...inputProps} {...focusProps} ref={ref} />
       <Icon
         img={img}
         width={props.width ? props.width : 20}

--- a/src/ui/StopListContainer.tsx
+++ b/src/ui/StopListContainer.tsx
@@ -155,6 +155,7 @@ const StopList = props => {
                       onStopMove={props.onStopMove}
                       setStops={props.setStops}
                       rightStops={rightItems}
+                      languages={languages}
                     />
                   </li>
                 );
@@ -189,6 +190,7 @@ const StopList = props => {
                         onStopMove={props.onStopMove}
                         setStops={props.setStops}
                         leftStops={leftItems}
+                        languages={languages}
                       />
                     </li>
                   );

--- a/src/ui/StopRoutesModal.scss
+++ b/src/ui/StopRoutesModal.scss
@@ -153,7 +153,6 @@
           margin-bottom: 10px;
 
           .lang {
-            position: absolute;
             font-style: normal;
             font-weight: $font-weight;
             font-size: 13px;
@@ -161,16 +160,9 @@
             letter-spacing: -0.02em;
             display: flex;
 
-            &.fi {
-              left: 136px;
-            }
-
+            &.fi,
             &.sv {
-              left: 290px;
-            }
-
-            &.en {
-              left: 444px;
+              margin-right: 144px;
             }
           }
         }

--- a/src/ui/StopRoutesModal.scss
+++ b/src/ui/StopRoutesModal.scss
@@ -117,7 +117,7 @@
           .en,
           .fi,
           .sv {
-            width: 130px;
+            width: 115px;
 
             &.readonly {
               font-size: 16px;

--- a/src/ui/StopRoutesModal.scss
+++ b/src/ui/StopRoutesModal.scss
@@ -16,21 +16,23 @@
     border: none !important;
     border-radius: 5px !important;
     width: 720px !important;
-    height: 80% !important;
-    overflow-x: hidden !important;
+    height: 85% !important;
     top: 50% !important;
     left: 50% !important;
+    overflow: hidden !important;
     margin-right: -50%;
     margin-bottom: -50%;
     transform: translate(-50%, -50%);
     display: flex;
     justify-content: center;
     animation: none;
+    padding: 0 !important;
   }
 
   #close {
-    display: flex;
-    justify-content: flex-end;
+    position: absolute;
+    top: 30px;
+    right: 30px;
 
     .close-button {
       background: transparent;
@@ -39,12 +41,16 @@
     }
   }
 
-  #section-with-side-padding {
-    padding: 0 40px;
+  .section-margin-small {
+    margin: 0 60px;
+  }
+
+  .section-margin-large {
+    margin: 0 80px;
   }
 
   .title-container {
-    margin-bottom: 22px;
+    margin: 64px 0 22px 0;
 
     .title {
       font-size: 22px;
@@ -59,16 +65,17 @@
 
   .modal {
     padding-top: 0;
-    width: 600px;
+    width: 720px;
     font-family: $font-family;
     margin: 0;
+    overflow-y: auto;
 
     .route-rows {
       display: flex;
       flex-direction: column;
       overflow-y: auto;
       overflow-x: hidden;
-      max-height: 380px;
+      max-height: 325px;
 
       .row {
         min-height: 30px;
@@ -76,9 +83,15 @@
         align-items: center;
         margin: 10px 0;
 
+        .check-box {
+          svg {
+            flex: none;
+          }
+        }
+
         .empty-space,
         .reserved-space {
-          width: 146px;
+          width: 160px;
         }
 
         .option-checkbox-container {
@@ -117,11 +130,11 @@
           .en,
           .fi,
           .sv {
-            width: 115px;
+            width: 105px;
 
             &.readonly {
               font-size: 16px;
-              width: 132px;
+              width: 109px;
               border: 0;
 
               &::placeholder {
@@ -136,7 +149,7 @@
 
           .fi,
           .sv {
-            margin-right: 18px;
+            margin-right: 13px;
           }
 
           .fi {
@@ -162,7 +175,7 @@
 
             &.fi,
             &.sv {
-              margin-right: 144px;
+              margin-right: 114px;
             }
           }
         }

--- a/src/ui/StopRoutesModal.tsx
+++ b/src/ui/StopRoutesModal.tsx
@@ -26,6 +26,7 @@ interface Props {
   closeModal: (route: IRoute[]) => void;
   stopSettings?: any;
   combinedPatterns: string[];
+  languages: Array<string>;
 }
 export const defaultSettings = {
   hiddenRoutes: [],
@@ -146,9 +147,9 @@ const StopRoutesModal: FC<Props & WithTranslation> = (
         const inputFI = document?.getElementById(`fi-${p}`) as HTMLInputElement;
         const inputSV = document?.getElementById(`sv-${p}`) as HTMLInputElement;
         const inputEN = document?.getElementById(`en-${p}`) as HTMLInputElement;
-        inputFI.value = '';
-        inputSV.value = '';
-        inputEN.value = '';
+        if (inputFI) inputFI.value = '';
+        if (inputSV) inputSV.value = '';
+        if (inputEN) inputEN.value = '';
       });
       setRenamings([]);
       setShowInputs(false);
@@ -204,6 +205,10 @@ const StopRoutesModal: FC<Props & WithTranslation> = (
     'showEndOfLine',
     'showVia',
   ];
+
+  const isLangSelected = lang => {
+    return props.languages.includes(lang);
+  };
 
   return (
     <Modal
@@ -323,9 +328,15 @@ const StopRoutesModal: FC<Props & WithTranslation> = (
           {(showInputs || renamings.length > 0) && (
             <div className={cx('row', 'small')}>
               <div className="empty-space"></div>
-              <div className={cx('lang', 'fi')}>FI</div>
-              <div className={cx('lang', 'sv')}>SV</div>
-              <div className={cx('lang', 'en')}>EN</div>
+              {isLangSelected('fi') && (
+                <div className={cx('lang', 'fi')}>FI</div>
+              )}
+              {isLangSelected('sv') && (
+                <div className={cx('lang', 'sv')}>SV</div>
+              )}
+              {isLangSelected('en') && (
+                <div className={cx('lang', 'en')}>EN</div>
+              )}
             </div>
           )}
           {props.combinedPatterns.map((pattern, index) => {
@@ -369,38 +380,44 @@ const StopRoutesModal: FC<Props & WithTranslation> = (
                   )}
                   {(showInputs || renamedDestination) && (
                     <div className="renamedDestinations">
-                      <input
-                        key={`i-${keyForInput}`}
-                        id={`fi-${pattern}`}
-                        name={pattern}
-                        className={cx('fi', !showInputs ? 'readonly' : '')}
-                        defaultValue={
-                          !showInputs && renamedDestination?.fi
-                            ? renamedDestination?.fi
-                            : undefined
-                        }
-                        onChange={e => handleRenamedDestination(e, 'fi')}
-                        placeholder={patternArray[3]}
-                        readOnly={!showInputs}
-                      />
-                      <input
-                        key={`i-${keyForInput + 1}`}
-                        id={`sv-${pattern}`}
-                        name={pattern}
-                        className={cx('sv', !showInputs ? 'readonly' : '')}
-                        defaultValue={renamedDestination?.sv}
-                        onChange={e => handleRenamedDestination(e, 'sv')}
-                        readOnly={!showInputs}
-                      />
-                      <input
-                        key={`i-${keyForInput + 2}`}
-                        id={`en-${pattern}`}
-                        name={pattern}
-                        className={cx('en', !showInputs ? 'readonly' : '')}
-                        defaultValue={renamedDestination?.en}
-                        onChange={e => handleRenamedDestination(e, 'en')}
-                        readOnly={!showInputs}
-                      />
+                      {isLangSelected('fi') && (
+                        <input
+                          key={`i-${keyForInput}`}
+                          id={`fi-${pattern}`}
+                          name={pattern}
+                          className={cx('fi', !showInputs ? 'readonly' : '')}
+                          defaultValue={
+                            !showInputs && renamedDestination?.fi
+                              ? renamedDestination?.fi
+                              : undefined
+                          }
+                          onChange={e => handleRenamedDestination(e, 'fi')}
+                          placeholder={patternArray[3]}
+                          readOnly={!showInputs}
+                        />
+                      )}
+                      {isLangSelected('sv') && (
+                        <input
+                          key={`i-${keyForInput + 1}`}
+                          id={`sv-${pattern}`}
+                          name={pattern}
+                          className={cx('sv', !showInputs ? 'readonly' : '')}
+                          defaultValue={renamedDestination?.sv}
+                          onChange={e => handleRenamedDestination(e, 'sv')}
+                          readOnly={!showInputs}
+                        />
+                      )}
+                      {isLangSelected('en') && (
+                        <input
+                          key={`i-${keyForInput + 2}`}
+                          id={`en-${pattern}`}
+                          name={pattern}
+                          className={cx('en', !showInputs ? 'readonly' : '')}
+                          defaultValue={renamedDestination?.en}
+                          onChange={e => handleRenamedDestination(e, 'en')}
+                          readOnly={!showInputs}
+                        />
+                      )}
                     </div>
                   )}
                 </Checkbox>

--- a/src/ui/StopRoutesModal.tsx
+++ b/src/ui/StopRoutesModal.tsx
@@ -7,7 +7,6 @@ import Icon from './Icon';
 import { withTranslation, WithTranslation } from 'react-i18next';
 import { IStop } from '../util/Interfaces';
 import Modal from 'react-modal';
-import { capitalize } from '../util/monitorUtils';
 import { getColorByName, getIconStyleWithColor } from '../util/getConfig';
 import { getStopIcon } from '../util/stopCardUtil';
 import { isKeyboardSelectionEvent } from '../util/browser';
@@ -206,10 +205,6 @@ const StopRoutesModal: FC<Props & WithTranslation> = (
     'showVia',
   ];
 
-  const isLangSelected = lang => {
-    return props.languages.includes(lang);
-  };
-
   return (
     <Modal
       isOpen={props.showModal}
@@ -232,12 +227,12 @@ const StopRoutesModal: FC<Props & WithTranslation> = (
             />
           </button>
         </section>
-        <section id="section-with-side-padding">
+        <section className="section-margin-large">
           <div className="title-container">
             <h2 className="title">{text}</h2>
           </div>
         </section>
-        <section id="section-with-side-padding">
+        <section className="section-margin-large">
           <h2 id="show-settings-group-label">{props.t('show')}</h2>
           {showSettings.map(setting => {
             return (
@@ -260,10 +255,10 @@ const StopRoutesModal: FC<Props & WithTranslation> = (
             );
           })}
         </section>
-        <section id="section-with-side-padding">
+        <section className="section-margin-small">
           <div className="divider" />
         </section>
-        <section id="section-with-side-padding" className="timeshift">
+        <section className="section-margin-large timeshift">
           <h2> {props.t('timeShift')}</h2>
           <p>{props.t('timeShiftDescription')}</p>
           <div className="show-departures-over">
@@ -277,13 +272,10 @@ const StopRoutesModal: FC<Props & WithTranslation> = (
             />
           </div>
         </section>
-        <section id="section-with-side-padding">
+        <section className="section-margin-small">
           <div className="divider" />
         </section>
-        <section
-          id="section-with-side-padding"
-          className="title-and-no-renaming"
-        >
+        <section className="section-margin-large title-and-no-renaming">
           <div className="title">
             <h2>
               {props.t('hideLines', {
@@ -311,7 +303,7 @@ const StopRoutesModal: FC<Props & WithTranslation> = (
             </h2>
           </div>
         </section>
-        <section id="section-with-side-padding" className="route-rows">
+        <section className="section-margin-large route-rows">
           <div className="row">
             <Checkbox
               isSelected={hiddenRouteChecked(null)}
@@ -325,18 +317,12 @@ const StopRoutesModal: FC<Props & WithTranslation> = (
               <span className="all">{props.t('all')}</span>
             </Checkbox>
           </div>
-          {(showInputs || renamings.length > 0) && (
+          {props.languages.length > 1 && (
             <div className={cx('row', 'small')}>
               <div className="empty-space"></div>
-              {isLangSelected('fi') && (
-                <div className={cx('lang', 'fi')}>FI</div>
-              )}
-              {isLangSelected('sv') && (
-                <div className={cx('lang', 'sv')}>SV</div>
-              )}
-              {isLangSelected('en') && (
-                <div className={cx('lang', 'en')}>EN</div>
-              )}
+              {props.languages.map(lang => (
+                <div className={cx('lang', lang)}>{lang.toUpperCase()}</div>
+              ))}
             </div>
           )}
           {props.combinedPatterns.map((pattern, index) => {
@@ -347,11 +333,9 @@ const StopRoutesModal: FC<Props & WithTranslation> = (
             const keyForInput = 3 * index + 1;
             const patternArray = pattern.split(':');
             const iconStyle = getIconStyleWithColor(getStopIcon(props.stop));
-
             return (
-              <div key={`r-${index}`} className="row">
+              <div key={pattern} className="row">
                 <Checkbox
-                  key={`c-${index}`}
                   isSelected={hiddenRouteChecked(pattern)}
                   onChange={() => checkHiddenRoute(pattern)}
                   name={pattern}
@@ -373,66 +357,32 @@ const StopRoutesModal: FC<Props & WithTranslation> = (
                     />
                   </div>
                   <div className="route-number">{patternArray[2]}</div>
-                  {!showInputs && !renamedDestination && (
-                    <div className="destination">
-                      {capitalize(patternArray[3])}
-                    </div>
-                  )}
-                  {(showInputs || renamedDestination) && (
-                    <div className="renamedDestinations">
-                      {isLangSelected('fi') && (
-                        <input
-                          key={`i-${keyForInput}`}
-                          id={`fi-${pattern}`}
-                          name={pattern}
-                          className={cx('fi', !showInputs ? 'readonly' : '')}
-                          defaultValue={
-                            !showInputs && renamedDestination?.fi
-                              ? renamedDestination?.fi
-                              : undefined
-                          }
-                          onChange={e => handleRenamedDestination(e, 'fi')}
-                          placeholder={patternArray[3]}
-                          readOnly={!showInputs}
-                        />
-                      )}
-                      {isLangSelected('sv') && (
-                        <input
-                          key={`i-${keyForInput + 1}`}
-                          id={`sv-${pattern}`}
-                          name={pattern}
-                          className={cx('sv', !showInputs ? 'readonly' : '')}
-                          defaultValue={renamedDestination?.sv}
-                          onChange={e => handleRenamedDestination(e, 'sv')}
-                          readOnly={!showInputs}
-                        />
-                      )}
-                      {isLangSelected('en') && (
-                        <input
-                          key={`i-${keyForInput + 2}`}
-                          id={`en-${pattern}`}
-                          name={pattern}
-                          className={cx('en', !showInputs ? 'readonly' : '')}
-                          defaultValue={renamedDestination?.en}
-                          onChange={e => handleRenamedDestination(e, 'en')}
-                          readOnly={!showInputs}
-                        />
-                      )}
-                    </div>
-                  )}
                 </Checkbox>
+                <div className="renamedDestinations">
+                  {props.languages.map(lang => (
+                    <input
+                      key={`${lang}-${pattern}`}
+                      id={`${lang}-${pattern}`}
+                      name={pattern}
+                      className={cx(lang, !showInputs ? 'readonly' : '')}
+                      defaultValue={
+                        renamedDestination?.[lang]
+                          ? renamedDestination[lang]
+                          : undefined
+                      }
+                      onChange={e => handleRenamedDestination(e, lang)}
+                      placeholder={patternArray[3]}
+                      readOnly={!showInputs}
+                    />
+                  ))}
+                </div>
               </div>
             );
           })}
         </section>
-        <section id="section-with-side-padding">
+        <section className="section-margin-small">
           <div className="divider-routes" />
-          <div
-            className={cx(
-              'button-container',
-              props.combinedPatterns.length < 5 ? 'less' : '',
-            )}
-          >
+          <div className="button-container">
             <Button onClick={handleSave} text={props.t('save')} />
           </div>
         </section>

--- a/src/ui/StopRow.tsx
+++ b/src/ui/StopRow.tsx
@@ -38,6 +38,7 @@ interface IProps {
   ) => void;
   readonly leftStops?: Array<IStopInfoPlus>;
   readonly rightStops?: Array<IStopInfoPlus>;
+  readonly languages: Array<string>;
 }
 
 const moveIsPossible = (stop, stopList) => {
@@ -56,6 +57,7 @@ const StopRow: FC<IProps & WithTranslation> = ({
   t,
   leftStops,
   rightStops,
+  languages,
 }) => {
   const [showModal, changeOpen] = useState(false);
   const saveStopSettings = settings => {
@@ -135,6 +137,7 @@ const StopRow: FC<IProps & WithTranslation> = ({
             showModal={showModal}
             stop={stop}
             combinedPatterns={combinedPatterns}
+            languages={languages}
           />
         )}
         <div className="stop-bottom-row">


### PR DESCRIPTION
* [Add props that were needed to monitor.ts](https://github.com/HSLdevcom/digitransit-virtualmonitor/commit/83b8c5c5e7bc22cd2237b7a7f9ec760c4a5ae052)[](https://github.com/Antiik91)
* [language selection also affects the renaming inputs in stop settings](https://github.com/HSLdevcom/digitransit-virtualmonitor/commit/a9117392801ef2e50e0d38dac9f388c3eca1ba3b)
* [Adjust input size in stopRoutesModal](https://github.com/HSLdevcom/digitransit-virtualmonitor/commit/407e6cbef63f9694a3a79e5373d064feefcdd700)