### PR TITLE
DT-5402: Stop monitor departures issue in east / west layout

### DIFF
--- a/src/ui/InformationDisplay.scss
+++ b/src/ui/InformationDisplay.scss
@@ -1,5 +1,5 @@
 .information-monitor-container {
-  margin: 8vh 2vh;
+  margin: 8vh 4vh;
 
   .alert-header {
     font-size: 5vh;

--- a/src/ui/MonitorRowContainer.scss
+++ b/src/ui/MonitorRowContainer.scss
@@ -75,6 +75,7 @@ $preview-grid-divider: 2px;
 
       .row-with-separator.alert {
         width: calc(200% + 35px) !important;
+        left: -9px;
       }
     }
 
@@ -193,6 +194,14 @@ $preview-grid-divider: 2px;
 
   .monitor-container {
     flex: 1;
+
+    .rows8 .no-departures-text-container {
+      flex: 6;
+    }
+
+    .rows12 .no-departures-text-container {
+      flex: 9;
+    }
 
     .no-departures-text-container {
       flex: 3;
@@ -396,7 +405,7 @@ $preview-grid-divider: 2px;
 
       &.alert {
         position: relative;
-        left: -15px;
+        left: -13px;
         width: calc(100% + 30px);
 
         .grid-row {

--- a/src/ui/MonitorRowContainer.tsx
+++ b/src/ui/MonitorRowContainer.tsx
@@ -201,7 +201,6 @@ const MonitorRowContainer: FC<IProps & WithTranslation> = ({
       }
     }
   }
-
   const headers = (columns, stops) => {
     let withStopCode = false;
     stops.forEach(s => {
@@ -272,10 +271,13 @@ const MonitorRowContainer: FC<IProps & WithTranslation> = ({
     closedStopIndex !== -1 &&
     closedStopViews[closedStopIndex].column === 'right';
 
-  const noDepartures =
-    !departuresLeft.length && !departuresRight.length
-      ? t('noMonitors')
-      : undefined;
+  const noKnownDeparturesLeft =
+    !departuresLeft.length &&
+    !leftStops.every(s => s.settings?.allRoutesHidden);
+  const noKnownDeparturesRight =
+    !departuresRight.length &&
+    !rightStops.every(s => s.settings?.allRoutesHidden);
+
   return (
     <div
       className={cx('monitor-container', {
@@ -307,11 +309,11 @@ const MonitorRowContainer: FC<IProps & WithTranslation> = ({
               portrait: !isLandscape,
               'two-cols': withTwoColumns,
               tightened: isTighten,
-              'no-departures': departuresLeft.length === 0,
+              'no-departures': isClosedStopOnLeft,
             },
           )}
         >
-          {departuresLeft.length > 0 ? (
+          {!isClosedStopOnLeft && !noKnownDeparturesLeft ? (
             <>{isTighten ? leftColumn.slice(tighten[0]) : leftColumn}</>
           ) : (
             <div className="no-departures-text-container">
@@ -320,25 +322,21 @@ const MonitorRowContainer: FC<IProps & WithTranslation> = ({
                   'closed-stop': isClosedStopOnLeft,
                 })}
               >
-                {isClosedStopOnLeft ? (
-                  t('closedStopWithRange', {
-                    lng: currentLang,
-                    name: closedStopViews[closedStopIndex].name,
-                    code: closedStopViews[closedStopIndex].code,
-                    startTime: formattedDateTimeFromSeconds(
-                      closedStopViews[closedStopIndex].startTime,
-                      DATE_FORMAT,
-                    ),
-                    endTime: formattedDateTimeFromSeconds(
-                      closedStopViews[closedStopIndex].endTime,
-                      DATE_FORMAT,
-                    ),
-                  })
-                ) : (
-                  <>
-                    {noDepartures || t('no-departures', { lng: currentLang })}
-                  </>
-                )}
+                {isClosedStopOnLeft
+                  ? t('closedStopWithRange', {
+                      lng: currentLang,
+                      name: closedStopViews[closedStopIndex].name,
+                      code: closedStopViews[closedStopIndex].code,
+                      startTime: formattedDateTimeFromSeconds(
+                        closedStopViews[closedStopIndex].startTime,
+                        DATE_FORMAT,
+                      ),
+                      endTime: formattedDateTimeFromSeconds(
+                        closedStopViews[closedStopIndex].endTime,
+                        DATE_FORMAT,
+                      ),
+                    })
+                  : t('no-departures', { lng: currentLang })}
               </div>
             </div>
           )}
@@ -360,8 +358,7 @@ const MonitorRowContainer: FC<IProps & WithTranslation> = ({
                   'no-departures': departuresRight.length > 0,
                 })}
               >
-                {departuresRight.length === 0 &&
-                !(departuresLeft.length > leftColumnCount) ? (
+                {isClosedStopOnRight || noKnownDeparturesRight ? (
                   <>
                     <div className="no-departures-text-container">
                       <div
@@ -386,7 +383,6 @@ const MonitorRowContainer: FC<IProps & WithTranslation> = ({
                           : t('no-departures', { lng: currentLang })}
                       </div>
                     </div>
-
                     {alertComponent && <div className="alert-padding"></div>}
                   </>
                 ) : (

--- a/src/ui/MonitorRowContainer.tsx
+++ b/src/ui/MonitorRowContainer.tsx
@@ -309,7 +309,7 @@ const MonitorRowContainer: FC<IProps & WithTranslation> = ({
               portrait: !isLandscape,
               'two-cols': withTwoColumns,
               tightened: isTighten,
-              'no-departures': isClosedStopOnLeft,
+              'no-departures': isClosedStopOnLeft || noKnownDeparturesLeft,
             },
           )}
         >
@@ -355,7 +355,8 @@ const MonitorRowContainer: FC<IProps & WithTranslation> = ({
               <div
                 className={cx('grid-rows', `rows${rightColumnCount}`, {
                   'two-cols': withTwoColumns,
-                  'no-departures': departuresRight.length > 0,
+                  'no-departures':
+                    isClosedStopOnRight || noKnownDeparturesRight,
                 })}
               >
                 {isClosedStopOnRight || noKnownDeparturesRight ? (

--- a/src/util/monitorUtils.ts
+++ b/src/util/monitorUtils.ts
@@ -248,12 +248,17 @@ export const createDepartureArray = (
   }
   return [stringsToTranslate, departures, arr, closedStopViews];
 };
-
+/*
+ * An infromation display is a display that only shows alerts for the selected stops.
+ * It is created by making a single view stop monitor with default settings and hiding all
+ * of the departures on every stop.
+ */
 export const isInformationDisplay = cards => {
   return (
     cards.length === 1 &&
     cards[0].columns.left.stops.length &&
-    cards[0].columns.left.stops.every(stop => stop.settings?.allRoutesHidden)
+    cards[0].columns.left.stops.every(stop => stop.settings?.allRoutesHidden) &&
+    cards[0].layout === 1
   );
 };
 

--- a/src/util/monitorUtils.ts
+++ b/src/util/monitorUtils.ts
@@ -258,7 +258,7 @@ export const isInformationDisplay = cards => {
     cards.length === 1 &&
     cards[0].columns.left.stops.length &&
     cards[0].columns.left.stops.every(stop => stop.settings?.allRoutesHidden) &&
-    cards[0].layout === 1
+    cards[0].layout === 2
   );
 };
 


### PR DESCRIPTION
 - Monitor only turns into an information display with the first layout option
 - Sensible messages when no departures are found: 
   - If user hides all routes, empty rows are shown
   - If all routes are not hidden and no departures are found, a message telling no departures were found is shown