### PR TITLE
DT-5533: Logging in on edit page returns a blank view

### DIFF
--- a/server/auth/openidConnect.js
+++ b/server/auth/openidConnect.js
@@ -170,14 +170,14 @@ function setUpOIDC(app, port, indexPath, hostnames, paths, localPort) {
   // users will be redirected to hsl.id and once authenticated
   // they will be returned to the callback handler below
   app.get('/login', (req, res) => {
-    const { url, favouriteModalAction, ...rest } = req.query;
-    // if (favouriteModalAction) {
-    //   req.session.returnTo = `/${indexPath}?favouriteModalAction=${favouriteModalAction}`;
-    // }
+    const { url, ...rest } = req.query;
+
     if (url) {
       const restParams = Object.keys(rest)
         .map(k => `${k}=${rest[k]}`)
-        .join('&');
+        .join('&')
+        .replaceAll(' ', '+');
+      
       req.session.returnTo = localPort
         ? `http://localhost:${localPort}${url}?${restParams}`
         : `${url}?${restParams}`;

--- a/src/ui/CreateViewPage.tsx
+++ b/src/ui/CreateViewPage.tsx
@@ -61,6 +61,8 @@ const CreateViewPage = () => {
             if (r.languages) {
               setLanguages(r.languages);
             }
+          } else {
+            setNoMonitorFound(true);
           }
           setLoading(false);
         })
@@ -117,15 +119,16 @@ const CreateViewPage = () => {
   }
 
   if (
-    user.sub &&
+    user?.sub &&
     location.pathname.toLowerCase() === '/createview' &&
     !url &&
     !hash &&
     !location.state?.view
   ) {
+    // user is trying to access the non logged in create page while logged in,
+    // redirect to correct page
     return <Redirect to={{ pathname: '/monitors/createview' }} />;
   }
-
   if (((!hash && !url) || noMonitorFound) && !location?.state?.view) {
     return (
       <ContentContainer>


### PR DESCRIPTION
 - Trying to access edit page with an invalid url returned a blank page
 - Fixed logging in edit page breaking the url and returning an empty page