### PR TITLE
fix: digitraffic added to feedIds

### DIFF
--- a/src/defaultConfig.js
+++ b/src/defaultConfig.js
@@ -4,7 +4,15 @@ export default {
     monitorBackground: '#0057a2',
     alert: '#dc0451',
   },
-  feedIds: ['MATKA', 'HSL', 'tampere', 'LINKKI', 'lautta', 'OULU'],
+  feedIds: [
+    'MATKA',
+    'HSL',
+    'tampere',
+    'LINKKI',
+    'lautta',
+    'OULU',
+    'digitraffic',
+  ],
   fonts: {
     weights: {
       normal: '400',


### PR DESCRIPTION
Trains were not appearing in the search in Matka.fi. The digitraffic feedId was missing and has now been added. 