### PR TITLE
chore: Call pelias through the backend services

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -64,6 +64,21 @@ app.use('/api/graphql', (req, res, next) => {
     .catch((e) => next(e));
 });
 
+app.get('/api/geocoding/:endpoint', (req, res, next) => {
+  const baseurl = process.env.API_URL ?? 'https://dev-api.digitransit.fi';
+  const endpoint = `/geocoding/v1/${req.params.endpoint}`;
+  const apiSubscriptionParameter = process.env.API_SUBSCRIPTION_QUERY_PARAMETER_NAME
+    ? `&${process.env.API_SUBSCRIPTION_QUERY_PARAMETER_NAME}=${process.env.API_SUBSCRIPTION_TOKEN}`
+    : '';
+  const url = `${baseurl}/${endpoint}?${req._parsedUrl.query}${apiSubscriptionParameter}`;
+
+  axios.get(url)
+    .then(function (response) {
+      res.json(response.data);
+    })
+    .catch((e) => next(e));
+});
+
 app.put('/api/monitor', (req, res, next) => {
   monitorService.create(req, res, next);
 });

--- a/src/ui/searchContext.ts
+++ b/src/ui/searchContext.ts
@@ -1,7 +1,7 @@
 export function getSearchContext(config) {
   const searchContext = {
-    URL_PELIAS: 'https://api.digitransit.fi/geocoding/v1/search',
-    URL_PELIAS_PLACE: 'https://api.digitransit.fi/geocoding/v1/place',
+    URL_PELIAS: '/api/geocoding/search',
+    URL_PELIAS_PLACE: '/api/geocoding/place',
     isPeliasLocationAware: false, // true / false does Let Pelias suggest based on current user location
     minimalRegexp: undefined, // used for testing min. regexp. For example: new RegExp('.{2,}'),
     lineRegexp: new RegExp(


### PR DESCRIPTION
Geocoding searches go through the backend services before the geocoding api is called. 