### PR TITLE
DT-5627 adjusting layouts for longer train line codes

### DIFF
--- a/src/ui/MonitorRowLayouts.scss
+++ b/src/ui/MonitorRowLayouts.scss
@@ -7,6 +7,7 @@
 }
 
 .rows4 .grid-row {
+  grid-template-columns: 23vh 1fr 36vh;
   font-size: calc((#{var(--height)} - 30vh) / 11.5);
 
   .len1,
@@ -20,7 +21,7 @@
 }
 
 .rows8 .grid-row {
-  grid-template-columns: 18vh 1fr 25vh;
+  grid-template-columns: 21vh 1fr 25vh;
   font-size: calc((#{var(--height)} - 30vh) / 13);
 
   &.without-route-column {
@@ -29,7 +30,7 @@
 }
 
 .rows8 .grid-row.with-stop-code {
-  grid-template-columns: 18vh 1fr 20vh 25vh;
+  grid-template-columns: 21vh 1fr 20vh 25vh;
 
   &.without-route-column {
     grid-template-columns: auto 20vh 25vh;
@@ -54,7 +55,7 @@
 }
 
 .rows4 .grid-row.with-stop-code {
-  grid-template-columns: 20vh 1fr 20vh 36vh;
+  grid-template-columns: 23vh 1fr 20vh 36vh;
 
   &.without-route-column {
     grid-template-columns: auto 20vh 36vh;
@@ -77,8 +78,12 @@
   }
 }
 
+.rows8.two-cols .grid-row {
+  grid-template-columns: 21vh 1fr 18vh;
+}
+
 .rows8.two-cols .grid-row.with-stop-code {
-  grid-template-columns: 15vh 1fr 17vh 18vh;
+  grid-template-columns: 21vh 1fr 17vh 18vh;
 
   &.without-route-column {
     grid-template-columns: auto 17vh 18vh;
@@ -94,7 +99,7 @@
 }
 
 .rows8.portrait .grid-row.with-stop-code {
-  grid-template-columns: 12vh 1fr 12vh 17vh;
+  grid-template-columns: 19vh 1fr 12vh 17vh;
 
   &.without-route-column {
     grid-template-columns: auto 12vh 17vh;
@@ -107,7 +112,7 @@
 
 .rows12.portrait .grid-row {
   font-size: calc((#{var(--height)} - 30vh) / 18);
-  grid-template-columns: 12vh 1fr 17vh;
+  grid-template-columns: 15vh 1fr 17vh;
 
   &.without-route-column {
     grid-template-columns: auto 17vh;
@@ -115,7 +120,7 @@
 }
 
 .rows12.portrait .grid-row.with-stop-code {
-  grid-template-columns: 12vh 1fr 11vh 17vh;
+  grid-template-columns: 15vh 1fr 11vh 17vh;
 
   &.without-route-column {
     grid-template-columns: auto 11vh 17vh;
@@ -123,7 +128,7 @@
 }
 
 .rows16.portrait .grid-row.with-stop-code {
-  grid-template-columns: 12vh 1fr 10vh 15vh;
+  grid-template-columns: 15vh 1fr 10vh 15vh;
 
   &.without-route-column {
     grid-template-columns: auto 10vh 15vh;
@@ -139,7 +144,7 @@
 }
 
 .rows4.portrait.tightened .grid-row.with-stop-code {
-  grid-template-columns: 12vh 1fr 13vh 15vh;
+  grid-template-columns: 17vh 1fr 13vh 15vh;
 
   &.without-route-column {
     grid-template-columns: auto 13vh 15vh;
@@ -147,11 +152,16 @@
 }
 
 .rows12.portrait.tightened .grid-row {
+  grid-template-columns: 17vh 1fr 15vh;
   font-size: calc((#{var(--height)} - 30vh) / 26);
 }
 
+.rows12.portrait.tightened .grid-row.with-stop-code {
+  grid-template-columns: 17vh 1fr 13vh 15vh;
+}
+
 .rows6.portrait.tightened .grid-row.with-stop-code {
-  grid-template-columns: 12vh 1fr 13vh 15vh;
+  grid-template-columns: 17vh 1fr 13vh 15vh;
 
   &.without-route-column {
     grid-template-columns: auto 13vh 15vh;
@@ -159,7 +169,7 @@
 }
 
 .rows4.portrait .grid-row {
-  grid-template-columns: 12vh 1fr 22vh;
+  grid-template-columns: 17vh 1fr 22vh;
 
   &.without-route-column {
     grid-template-columns: auto 22vh;
@@ -175,7 +185,7 @@
 
 .rows6.portrait .grid-row {
   font-size: calc((#{var(--height)} - 30vh) / 16);
-  grid-template-columns: 12vh 1fr 15vh;
+  grid-template-columns: 17vh 1fr 15vh;
 
   &.without-route-column {
     grid-template-columns: auto 15vh;
@@ -183,7 +193,7 @@
 }
 
 .rows8.portrait .grid-row {
-  grid-template-columns: 12vh 1fr 17vh;
+  grid-template-columns: 19vh 1fr 17vh;
 
   &.without-route-column {
     grid-template-columns: auto 17vh;
@@ -198,7 +208,7 @@
 }
 
 .rows16.portrait .grid-row {
-  grid-template-columns: 12vh 1fr 15vh;
+  grid-template-columns: 15vh 1fr 15vh;
 
   &.without-route-column {
     grid-template-columns: auto 15vh;
@@ -219,7 +229,7 @@
 
 .preview {
   .rows4 .grid-row {
-    grid-template-columns: 160px 1fr 100px;
+    grid-template-columns: 120px 1fr 100px;
     font-size: 30px;
 
     .len1,
@@ -262,7 +272,7 @@
   }
 
   .rows12 .grid-row {
-    grid-template-columns: 60px 1fr 60px;
+    grid-template-columns: 7vh 1fr 60px;
 
     &.without-route-column {
       grid-template-columns: auto 60px;
@@ -272,7 +282,7 @@
   }
 
   .rows12 .grid-row.with-stop-code {
-    grid-template-columns: 60px 1fr 60px 60px;
+    grid-template-columns: 7vh 1fr 60px 60px;
 
     &.without-route-column {
       grid-template-columns: auto 60px 60px;
@@ -280,7 +290,7 @@
   }
 
   .rows4.two-cols .grid-row {
-    grid-template-columns: 65px 1fr 75px;
+    grid-template-columns: 9vh 1fr 60px;
 
     &.without-route-column {
       grid-template-columns: auto 80px;
@@ -290,7 +300,7 @@
   }
 
   .rows4.two-cols .grid-row.with-stop-code {
-    grid-template-columns: 65px 1fr 60px 75px;
+    grid-template-columns: 9vh 1fr 60px 60px;
 
     &.without-route-column {
       grid-template-columns: auto 70px 80px;
@@ -300,7 +310,7 @@
   }
 
   .rows8.two-cols .grid-row {
-    grid-template-columns: 60px 1fr 80px;
+    grid-template-columns: 8vh 1fr 60px;
 
     &.without-route-column {
       grid-template-columns: auto 80px;
@@ -308,7 +318,7 @@
   }
 
   .rows8.two-cols .grid-row.with-stop-code {
-    grid-template-columns: 55px 1fr 60px 75px;
+    grid-template-columns: 8vh 1fr 60px 60px;
 
     &.without-route-column {
       grid-template-columns: auto 60px 80px;
@@ -316,7 +326,7 @@
   }
 
   .rows8.portrait .grid-row {
-    grid-template-columns: 75px 1fr 80px;
+    grid-template-columns: 100px 1fr 80px;
 
     &.without-route-column {
       grid-template-columns: auto 80px;
@@ -326,20 +336,24 @@
 
     .len1,
     .len2 {
-      font-size: 50px;
+      font-size: 30px;
     }
   }
 
   .rows8.portrait .grid-row.with-stop-code {
-    grid-template-columns: 75px 1fr 80px 80px;
+    grid-template-columns: 100px 1fr 80px 80px;
 
     &.without-route-column {
       grid-template-columns: auto 80px 80px;
     }
+
+    .grid-col {
+      align-self: center;
+    }
   }
 
   .rows12.portrait .grid-row.with-stop-code {
-    grid-template-columns: 75px 1fr 70px 95px;
+    grid-template-columns: 95px 1fr 70px 95px;
 
     &.without-route-column {
       grid-template-columns: auto 70px 95px;
@@ -365,7 +379,7 @@
   }
 
   .rows6.tightened.portrait .grid-row {
-    grid-template-columns: 75px 1fr 95px;
+    grid-template-columns: 95px 1fr 95px;
 
     &.without-route-column {
       grid-template-columns: auto 95px;
@@ -395,7 +409,7 @@
   }
 
   .rows12.portrait .grid-row {
-    grid-template-columns: 75px 1fr 95px;
+    grid-template-columns: 95px 1fr 95px; // Tämä vaikuttaa tuplanäkymän alaosaan  95px 1fr 95px; JA yksittäiseen
 
     &.without-route-column {
       grid-template-columns: auto 95px;
@@ -435,8 +449,12 @@
     font-size: 15px;
   }
 
+  .rows4.portrait.tightened .grid-row {
+    grid-template-columns: 95px 1fr 70px;
+  }
+
   .rows4.portrait.tightened .grid-row.with-stop-code {
-    grid-template-columns: 75px 1fr 70px 95px;
+    grid-template-columns: 95px 1fr 70px 95px;
 
     &.without-route-column {
       grid-template-columns: auto 70px 95px;
@@ -444,7 +462,7 @@
   }
 
   .rows6.portrait.tightened .grid-row.with-stop-code {
-    grid-template-columns: 75px 1fr 70px 95px;
+    grid-template-columns: 95px 1fr 70px 95px;
 
     &.without-route-column {
       grid-template-columns: auto 70px 95px;
@@ -461,7 +479,7 @@
   }
 
   .rows12.portrait.tightened .grid-row.with-stop-code {
-    grid-template-columns: 75px 1fr 70px 95px;
+    grid-template-columns: 95px 1fr 70px 95px;
 
     &.without-route-column {
       grid-template-columns: auto 70px 95px;

--- a/src/ui/MonitorRowLayouts.scss
+++ b/src/ui/MonitorRowLayouts.scss
@@ -272,7 +272,7 @@
   }
 
   .rows12 .grid-row {
-    grid-template-columns: 7vh 1fr 60px;
+    grid-template-columns: 8vh 1fr 60px;
 
     &.without-route-column {
       grid-template-columns: auto 60px;
@@ -282,7 +282,7 @@
   }
 
   .rows12 .grid-row.with-stop-code {
-    grid-template-columns: 7vh 1fr 60px 60px;
+    grid-template-columns: 11vh 1fr 60px 60px;
 
     &.without-route-column {
       grid-template-columns: auto 60px 60px;
@@ -310,7 +310,7 @@
   }
 
   .rows8.two-cols .grid-row {
-    grid-template-columns: 8vh 1fr 60px;
+    grid-template-columns: 11vh 1fr 60px;
 
     &.without-route-column {
       grid-template-columns: auto 80px;
@@ -318,7 +318,7 @@
   }
 
   .rows8.two-cols .grid-row.with-stop-code {
-    grid-template-columns: 8vh 1fr 60px 60px;
+    grid-template-columns: 11vh 1fr 60px 60px;
 
     &.without-route-column {
       grid-template-columns: auto 60px 80px;

--- a/src/ui/MonitorRowLayouts.scss
+++ b/src/ui/MonitorRowLayouts.scss
@@ -409,7 +409,7 @@
   }
 
   .rows12.portrait .grid-row {
-    grid-template-columns: 95px 1fr 95px; // Tämä vaikuttaa tuplanäkymän alaosaan  95px 1fr 95px; JA yksittäiseen
+    grid-template-columns: 95px 1fr 95px;
 
     &.without-route-column {
       grid-template-columns: auto 95px;


### PR DESCRIPTION
Longer train line codes no longer cause ugly overflow in the previews and views. 
Destinations are also aligned even when there is a platform number on some lines but not others. 