### PR TITLE
Revert hsl font hotfix

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -126,12 +126,6 @@ const App: FC<IConfigurationProps> = props => {
   useEffect(() => {
     listenForLogoutAllTabs(setUser);
 
-    if (config.fonts.fontCounter) {
-      fetch(config.fonts.fontCounter, {
-        mode: 'no-cors',
-      });
-    }
-
     for (const i in style) {
       document.body.style.setProperty(i, style[i]);
     }

--- a/src/monitorConfig.js
+++ b/src/monitorConfig.js
@@ -1,8 +1,9 @@
 export default {
   hsl: {
     fonts: {
-      fontCounter: 'https://cloud.typography.com/6364294/7432412/css/fonts.css',
-      externalFonts: ['https://www.hsl.fi/fonts/784131/6C5FB8083F348CFBB.css'],
+      externalFonts: [
+        'https://cloud.typography.com/6364294/7432412/css/fonts.css',
+      ],
       normal: '"Gotham Rounded A","Gotham Rounded B", Arial, Georgia, Serif',
       weights: {
         normal: '400',


### PR DESCRIPTION
Reverts the HSL font url back to its original state and removes the counter feature. 
