### PR TITLE
DT-5877: Renamed destinations resets after some time

### DIFF
--- a/src/ui/MonitorRow.tsx
+++ b/src/ui/MonitorRow.tsx
@@ -131,9 +131,21 @@ const MonitorRow: FC<IProps> = ({
     t => t.trans_id === departureDestination?.split(' via')[0],
   );
 
-  const renamedDestination = renamedDestinations.find(
-    dest => dest.pattern === departure.combinedPattern,
-  );
+  const renamedDestination = renamedDestinations.find(dest => {
+    const headsign = departure.headsign ? departure.headsign : '';
+    const renameDestId = (
+      departure.trip.route.gtfsId +
+      ' - ' +
+      headsign
+    ).toLowerCase();
+    const found = dest.pattern.toLowerCase() === renameDestId;
+
+    // Backwards combatibility
+    if (!found) {
+      return dest.pattern === departure.combinedPattern;
+    }
+    return found;
+  });
 
   let destination = '';
   if (renamedDestination && renamedDestination[currentLang] !== '') {

--- a/src/ui/MonitorRow.tsx
+++ b/src/ui/MonitorRow.tsx
@@ -132,14 +132,15 @@ const MonitorRow: FC<IProps> = ({
   );
 
   const renamedDestination = renamedDestinations.find(dest => {
-    const headsign = departure.headsign ? departure.headsign : '';
+    const headsign = departure.headsign
+      ? departure.headsign.split(' via')[0]
+      : '';
     const renameDestId = (
       departure.trip.route.gtfsId +
       ' - ' +
       headsign
     ).toLowerCase();
     const found = dest.pattern.toLowerCase() === renameDestId;
-
     // Backwards combatibility
     if (!found) {
       return dest.pattern === departure.combinedPattern;

--- a/src/ui/StopCardListContainer.tsx
+++ b/src/ui/StopCardListContainer.tsx
@@ -519,6 +519,12 @@ const StopCardListContainer: FC<IProps> = ({
   const noStops = checkNoStops(stopCardList);
   const makeButtonsDisabled = !(languages.length > 0 && !noStops);
   const isModifyView = window.location.href.indexOf('url=') !== -1;
+  const login = getConfig().login.inUse;
+  const isNew =
+    (login &&
+      window.location.href.indexOf('url=') === -1 &&
+      window.location.href.indexOf('cont=')) ||
+    (!login && window.location.href.indexOf('cont=') === -1);
   const newDisplayDisabled = stopCardList.find(
     c => c.layout > 17 && c.layout < 20,
   );
@@ -657,7 +663,7 @@ const StopCardListContainer: FC<IProps> = ({
           <button
             disabled={makeButtonsDisabled}
             className="button blue"
-            onClick={() => createOrSaveMonitor(true)}
+            onClick={() => createOrSaveMonitor(isNew)}
             aria-label={ariaLabelForCreate}
             title={makeButtonsDisabled ? ariaLabelForCreate : undefined}
           >
@@ -673,7 +679,7 @@ const StopCardListContainer: FC<IProps> = ({
               disabled={makeButtonsDisabled}
               className="button blue"
               title={makeButtonsDisabled ? ariaLabelForSave : undefined}
-              onClick={() => createOrSaveMonitor(false)}
+              onClick={() => createOrSaveMonitor(isNew)}
               aria-label={ariaLabelForSave}
             >
               <span>{t('save')}</span>

--- a/src/ui/StopCardListContainer.tsx
+++ b/src/ui/StopCardListContainer.tsx
@@ -523,7 +523,7 @@ const StopCardListContainer: FC<IProps> = ({
   const isNew =
     (login &&
       window.location.href.indexOf('url=') === -1 &&
-      window.location.href.indexOf('cont=')) ||
+      window.location.href.indexOf('cont=')) === -1 ||
     (!login && window.location.href.indexOf('cont=') === -1);
   const newDisplayDisabled = stopCardList.find(
     c => c.layout > 17 && c.layout < 20,

--- a/src/ui/StopRoutesModal.tsx
+++ b/src/ui/StopRoutesModal.tsx
@@ -343,14 +343,13 @@ const StopRoutesModal: FC<Props> = props => {
               p => p.route.gtfsId === gtfsID,
             );
             const alternateIcon = config.modeIcons.postfix;
-            // const rId = gtfsID + ' - ' + patternArray[3];
             return (
               <div key={pattern} className="row">
                 <div className="routeInfo">
                   <Checkbox
-                    isSelected={hiddenRouteChecked(renameId)}
-                    onChange={() => checkHiddenRoute(renameId)}
-                    name={renameId}
+                    isSelected={hiddenRouteChecked(pattern)}
+                    onChange={() => checkHiddenRoute(pattern)}
+                    name={pattern}
                     width={30}
                     height={30}
                     color={config.colors.primary}

--- a/src/ui/StopRoutesModal.tsx
+++ b/src/ui/StopRoutesModal.tsx
@@ -143,9 +143,19 @@ const StopRoutesModal: FC<Props> = props => {
   const handleDeleteRenamings = event => {
     if (event === null || isKeyboardSelectionEvent(event, true)) {
       props.combinedPatterns.forEach(p => {
-        const inputFI = document?.getElementById(`fi-${p}`) as HTMLInputElement;
-        const inputSV = document?.getElementById(`sv-${p}`) as HTMLInputElement;
-        const inputEN = document?.getElementById(`en-${p}`) as HTMLInputElement;
+        const patArr = p.split(':');
+        const renameDestId =
+          [patArr[0], patArr[1]].join(':') + ' - ' + patArr[3];
+
+        const inputFI = document?.getElementById(
+          `fi-${renameDestId}`,
+        ) as HTMLInputElement;
+        const inputSV = document?.getElementById(
+          `sv-${renameDestId}`,
+        ) as HTMLInputElement;
+        const inputEN = document?.getElementById(
+          `en-${renameDestId}`,
+        ) as HTMLInputElement;
         if (inputFI) inputFI.value = '';
         if (inputSV) inputSV.value = '';
         if (inputEN) inputEN.value = '';
@@ -322,22 +332,25 @@ const StopRoutesModal: FC<Props> = props => {
             </div>
           )}
           {props.combinedPatterns.map((pattern, index) => {
-            const renamedDestination = renamings?.find(
-              d => d.pattern === pattern,
-            );
             const patternArray = pattern.split(':');
             const gtfsID = [patternArray[0], patternArray[1]].join(':');
+            const renameId = gtfsID + ' - ' + patternArray[3];
+            const renamedDestination = renamings?.find(d => {
+              return d.pattern === renameId;
+            });
+
             const { route } = props.stop.patterns.find(
               p => p.route.gtfsId === gtfsID,
             );
             const alternateIcon = config.modeIcons.postfix;
+            // const rId = gtfsID + ' - ' + patternArray[3];
             return (
               <div key={pattern} className="row">
                 <div className="routeInfo">
                   <Checkbox
-                    isSelected={hiddenRouteChecked(pattern)}
-                    onChange={() => checkHiddenRoute(pattern)}
-                    name={pattern}
+                    isSelected={hiddenRouteChecked(renameId)}
+                    onChange={() => checkHiddenRoute(renameId)}
+                    name={renameId}
                     width={30}
                     height={30}
                     color={config.colors.primary}
@@ -364,9 +377,9 @@ const StopRoutesModal: FC<Props> = props => {
                   {props.languages.map(lang => (
                     <input
                       tabIndex={showInputs ? 1 : -1}
-                      key={`${lang}-${pattern}`}
-                      id={`${lang}-${pattern}`}
-                      name={pattern}
+                      key={`${lang}-${renameId}`}
+                      id={`${lang}-${renameId}`}
+                      name={renameId}
                       className={cx(lang, !showInputs ? 'readonly' : '')}
                       defaultValue={
                         renamedDestination?.[lang]

--- a/src/ui/StopRoutesModal.tsx
+++ b/src/ui/StopRoutesModal.tsx
@@ -81,6 +81,9 @@ const StopRoutesModal: FC<Props> = props => {
     setSettings(newSettings);
   };
 
+  const getRenameDestinationId = (patternArray: string[], gtfsId: string) =>
+    gtfsId + ' - ' + patternArray[3];
+
   const checkHiddenRoute = option => {
     if (option === 'all') {
       const routes =
@@ -144,9 +147,8 @@ const StopRoutesModal: FC<Props> = props => {
     if (event === null || isKeyboardSelectionEvent(event, true)) {
       props.combinedPatterns.forEach(p => {
         const patArr = p.split(':');
-        const renameDestId =
-          [patArr[0], patArr[1]].join(':') + ' - ' + patArr[3];
-
+        const gtfsID = [patArr[0], patArr[1]].join(':');
+        const renameDestId = getRenameDestinationId(patArr, gtfsID);
         const inputFI = document?.getElementById(
           `fi-${renameDestId}`,
         ) as HTMLInputElement;
@@ -334,7 +336,7 @@ const StopRoutesModal: FC<Props> = props => {
           {props.combinedPatterns.map((pattern, index) => {
             const patternArray = pattern.split(':');
             const gtfsID = [patternArray[0], patternArray[1]].join(':');
-            const renameId = gtfsID + ' - ' + patternArray[3];
+            const renameId = getRenameDestinationId(patternArray, gtfsID);
             const renamedDestination = renamings?.find(d => {
               return d.pattern === renameId;
             });


### PR DESCRIPTION
* Adjusted Renaming logic so that we are not using pattern id when determening the renameId. Instead we use route's gtfs id and headsign combo.
* Fixed logic that determines is the monitor new, or are we modifying current one.
