### PR TITLE
DT-5973 passport fails when session is undefined

### DIFF
--- a/server/auth/openidConnect.js
+++ b/server/auth/openidConnect.js
@@ -156,6 +156,8 @@ function setUpOIDC(app, port, indexPath, hostnames, paths, localPort) {
     const token = req?.user?.token;
     if (
       req.isAuthenticated() &&
+      req.session &&
+      token &&
       token.refresh_token &&
       dayjs().unix() >= token.expires_at
     ) {


### PR DESCRIPTION
- Added a check for session, as passport can't proceed without it and the app has to restart to recover. The problem occurs when the user has an expired or invalid refresh_token.
- Also added a check for token to ensure token.refresh_token always works. 