### PR TITLE
DT-5973 hsl alerts turned off

### DIFF
--- a/src/ui/BannerHSL.tsx
+++ b/src/ui/BannerHSL.tsx
@@ -31,7 +31,7 @@ const BannerHSL = () => {
       fetch(`${config.bannersUri}language=${i18n.language}`)
         .then(res => res.json())
         .then(data => {
-          setBanners(data);
+          setBanners([]); // setting alerts to site header is currently causing issues DT-5973
         });
     }
     return () => controller.abort();


### PR DESCRIPTION
Settings alerts to SiteHeader causes the HSL UI to crash, so alerts are not added for now. 