### PR TITLE
DT-6016 hsl site header version fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@digitransit-component/digitransit-component-autosuggest": "1.9.4",
         "@habx/apollo-multi-endpoint-link": "^2.5.0",
         "@hsl-fi/modal": "^0.3.1",
-        "@hsl-fi/site-header": "^4.2.2",
+        "@hsl-fi/site-header": "4.2.2",
         "@react-aria/checkbox": "^3.4.1",
         "@react-aria/focus": "^3.5.0",
         "@react-stately/toggle": "^3.2.3",
@@ -4058,15 +4058,6 @@
       "resolved": "https://registry.npmjs.org/@hsl-fi/content-delivery-api-types/-/content-delivery-api-types-0.1.5.tgz",
       "integrity": "sha512-lIeUJ2I0q+YcnsXdJtXS+4UcIS7X4PJW+9bvaLjkeCRi5X62XNRmXU3q1E6bT1hiuL5BPNQlnWSAh/SqbQLNpg=="
     },
-    "node_modules/@hsl-fi/error-view": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@hsl-fi/error-view/-/error-view-0.1.0.tgz",
-      "integrity": "sha512-RHml2Jc+3mvInfOa1xeougSG/a0sP++srcao1PtwhOPz+SPKLd9vxX26cn3GD3AX3cqumaEDnkwk1I0XDdOtag==",
-      "dependencies": {
-        "@hsl-fi/button": "^1.2.3",
-        "@hsl-fi/content-delivery-api-types": "^0.1.5"
-      }
-    },
     "node_modules/@hsl-fi/hooks": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@hsl-fi/hooks/-/hooks-1.2.3.tgz",
@@ -4137,16 +4128,15 @@
       }
     },
     "node_modules/@hsl-fi/site-header": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/@hsl-fi/site-header/-/site-header-4.3.3.tgz",
-      "integrity": "sha512-u+TlAv4KvEGPdTpJfGF16tK+xjXZP8g90cnDuiNgQuE8pxifcdpUp3jgokmah42QBzC+9acVDCQK3bYsHDrmeg==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@hsl-fi/site-header/-/site-header-4.2.2.tgz",
+      "integrity": "sha512-lOSjah3FOk5gx/AmFJw2+UyLvqZPVpebQLyFFDGD5F/I3nVW8uS3zbqnoltnMTU6HTGJmm7V5TunttO5Vn1scQ==",
       "dependencies": {
         "@hsl-fi/animated-spinner": "^0.2.0",
         "@hsl-fi/button": "^1.2.3",
         "@hsl-fi/container-spinner": "^0.3.1",
         "@hsl-fi/content-delivery-api-types": "^0.1.5",
-        "@hsl-fi/error-view": "^0.1.0",
-        "@hsl-fi/hooks": "^1.2.3",
+        "@hsl-fi/hooks": "^1.2.0",
         "@hsl-fi/hsl-link": "1.0.0",
         "@hsl-fi/icons": "^1.0.4",
         "@hsl-fi/sass": "^0.2.0",
@@ -25227,15 +25217,6 @@
       "resolved": "https://registry.npmjs.org/@hsl-fi/content-delivery-api-types/-/content-delivery-api-types-0.1.5.tgz",
       "integrity": "sha512-lIeUJ2I0q+YcnsXdJtXS+4UcIS7X4PJW+9bvaLjkeCRi5X62XNRmXU3q1E6bT1hiuL5BPNQlnWSAh/SqbQLNpg=="
     },
-    "@hsl-fi/error-view": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@hsl-fi/error-view/-/error-view-0.1.0.tgz",
-      "integrity": "sha512-RHml2Jc+3mvInfOa1xeougSG/a0sP++srcao1PtwhOPz+SPKLd9vxX26cn3GD3AX3cqumaEDnkwk1I0XDdOtag==",
-      "requires": {
-        "@hsl-fi/button": "^1.2.3",
-        "@hsl-fi/content-delivery-api-types": "^0.1.5"
-      }
-    },
     "@hsl-fi/hooks": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@hsl-fi/hooks/-/hooks-1.2.3.tgz",
@@ -25297,16 +25278,15 @@
       }
     },
     "@hsl-fi/site-header": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/@hsl-fi/site-header/-/site-header-4.3.3.tgz",
-      "integrity": "sha512-u+TlAv4KvEGPdTpJfGF16tK+xjXZP8g90cnDuiNgQuE8pxifcdpUp3jgokmah42QBzC+9acVDCQK3bYsHDrmeg==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@hsl-fi/site-header/-/site-header-4.2.2.tgz",
+      "integrity": "sha512-lOSjah3FOk5gx/AmFJw2+UyLvqZPVpebQLyFFDGD5F/I3nVW8uS3zbqnoltnMTU6HTGJmm7V5TunttO5Vn1scQ==",
       "requires": {
         "@hsl-fi/animated-spinner": "^0.2.0",
         "@hsl-fi/button": "^1.2.3",
         "@hsl-fi/container-spinner": "^0.3.1",
         "@hsl-fi/content-delivery-api-types": "^0.1.5",
-        "@hsl-fi/error-view": "^0.1.0",
-        "@hsl-fi/hooks": "^1.2.3",
+        "@hsl-fi/hooks": "^1.2.0",
         "@hsl-fi/hsl-link": "1.0.0",
         "@hsl-fi/icons": "^1.0.4",
         "@hsl-fi/sass": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@digitransit-component/digitransit-component-autosuggest": "1.9.4",
     "@habx/apollo-multi-endpoint-link": "^2.5.0",
     "@hsl-fi/modal": "^0.3.1",
-    "@hsl-fi/site-header": "^4.2.2",
+    "@hsl-fi/site-header": "4.2.2",
     "@react-aria/checkbox": "^3.4.1",
     "@react-aria/focus": "^3.5.0",
     "@react-stately/toggle": "^3.2.3",

--- a/src/ui/BannerHSL.tsx
+++ b/src/ui/BannerHSL.tsx
@@ -31,7 +31,7 @@ const BannerHSL = () => {
       fetch(`${config.bannersUri}language=${i18n.language}`)
         .then(res => res.json())
         .then(data => {
-          setBanners([]); // setting alerts to site header is currently causing issues DT-5973
+          setBanners(data);
         });
     }
     return () => controller.abort();


### PR DESCRIPTION
- Site header version locked to 4.2.2, as the higher minor version crashes with banner data. 
- Banner alerts enabled again.