### PR TITLE
DT-6037: Train monitors wont show error page

### DIFF
--- a/src/ui/TrainDataPreparer.tsx
+++ b/src/ui/TrainDataPreparer.tsx
@@ -60,6 +60,7 @@ interface IProps {
   stations?: Array<ICard>;
   stops?: Array<ICard>;
   setQueryError?: any;
+  queryError?: boolean;
   [x: string]: any;
 }
 

--- a/src/ui/WithDatabaseConnection.tsx
+++ b/src/ui/WithDatabaseConnection.tsx
@@ -124,6 +124,7 @@ const WithDatabaseConnection: FC<IProps> = ({ location }) => {
               stations={stations}
               stops={stops}
               setQueryError={setQueryError}
+              queryError={queryError}
             />
           ) : (
             <CarouselDataContainer


### PR DESCRIPTION
add queryError to train components