### PR TITLE
dt-5974 session needed for logout, log response info

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -227,7 +227,8 @@ app.use((err, req, res, next) => {
   console.error(
     `Request error (${err.response?.status}): ${err.message}
     url: ${req.url},
-    operation: ${req.body?.operationName}`
+    operation: ${req.body?.operationName}
+    response: (${err.response.status}) ${err.response.statusText}`
   );
 
   // render the error page

--- a/server/auth/Strategy.js
+++ b/server/auth/Strategy.js
@@ -145,10 +145,12 @@ OICStrategy.prototype.refresh = function (req) {
     })
     .catch(err => {
       console.error('Error refreshing tokens', err);
-      req.logout(function (err) {
-        if (err) { return next(err); }
-      });
-      req.session.destroy();
+      if (req.session) {
+        req.logout(function (err) {
+          if (err) { return next(err); }
+        });
+        req.session.destroy();
+      }
       this.fail(err);
     });
 };


### PR DESCRIPTION
- Added session check before attempting logout after token refresh failure (passport attempts to regenerate the session at login) 
- Added response logging to error handling