### PR TITLE
DT-6103: Stop Search does not show all of the results

### DIFF
--- a/src/ui/StopCardRow.tsx
+++ b/src/ui/StopCardRow.tsx
@@ -435,6 +435,7 @@ const StopCardRow: FC<IProps> = ({
               targets={['Stops']}
               modeIconColors={config.modeIcons.colors}
               modeSet={config.modeIcons.setName}
+              geocodingSize={40}
             />
           </div>
           <LayoutAndTimeContainer


### PR DESCRIPTION
Added a geoCodingSize paramater to the Autosuggest so we can determine how many results we want to have. Default is 10. Added value, so now 40 results is shown if available.