### PR TITLE
DT-5972 ensure logout completed before delete session

### DIFF
--- a/server/auth/Strategy.js
+++ b/server/auth/Strategy.js
@@ -145,12 +145,10 @@ OICStrategy.prototype.refresh = function (req) {
     })
     .catch(err => {
       console.error('Error refreshing tokens', err);
-      if (req.session) {
-        req.logout(function (err) {
-          if (err) { return next(err); }
-        });
+      req.logout(function (err) {
+        if (err) { return next(err); }
         req.session.destroy();
-      }
+      });
       this.fail(err);
     });
 };

--- a/server/auth/openidConnect.js
+++ b/server/auth/openidConnect.js
@@ -157,9 +157,8 @@ function setUpOIDC(app, port, indexPath, hostnames, paths, localPort) {
     if (
       req.isAuthenticated() &&
       req.session &&
-      token &&
-      token.refresh_token &&
-      dayjs().unix() >= token.expires_at
+      token?.refresh_token &&
+      dayjs().unix() >= token?.expires_at
     ) {
       const userData = JSON.stringify(req?.user?.data);
       let oidcStrategyName = '';
@@ -172,7 +171,7 @@ function setUpOIDC(app, port, indexPath, hostnames, paths, localPort) {
       return passport.authenticate(oidcStrategyName, {
         refresh: true,
         successReturnToOrRedirect: `/${req.path}`,
-        failureRedirect: `/${req.path}`,
+        failureRedirect: '/',
       })(req, res, next);
     }
     return next();


### PR DESCRIPTION
The newer version of Passport automatically regenerates the session after logout to mitigate session fixation attacks. The logout function also became asynchronous, so the entire logout functionality was not finished before session was deleted. Session is now deleted only after the logout is completed. Also, minor cleanup.