### PR TITLE
DT-5820 handle extra long line code

### DIFF
--- a/src/util/getResources.ts
+++ b/src/util/getResources.ts
@@ -207,7 +207,7 @@ export const getRouteCodeColumnWidth = (departures, view, fontSize) => {
     .slice(0, leftColumnCount)
     .concat(departures[1].slice(0, rightColumnCount));
 
-  const shortestRouteCodeLength = 3;
+  const shortestRouteCodeLength = 3; // The line code heading still fits
   const longestRouteCodeLength =
     departuresOnScreen?.reduce((a, b) => {
       const aLengthValue = a?.trip?.route?.shortName?.length;
@@ -217,7 +217,7 @@ export const getRouteCodeColumnWidth = (departures, view, fontSize) => {
       return bLength === undefined || aLength > bLength ? aLength : bLength;
     }, shortestRouteCodeLength) || shortestRouteCodeLength; // Minimum length to allow space for the column title.
   const longestPossibleRouteCodeLength =
-    longestRouteCodeLength > 7
+    longestRouteCodeLength > 7 // over 7 characters causes the icon to be shown
       ? shortestRouteCodeLength
       : longestRouteCodeLength;
 

--- a/src/util/getResources.ts
+++ b/src/util/getResources.ts
@@ -217,7 +217,9 @@ export const getRouteCodeColumnWidth = (departures, view, fontSize) => {
       return bLength === undefined || aLength > bLength ? aLength : bLength;
     }, shortestRouteCodeLength) || shortestRouteCodeLength; // Minimum length to allow space for the column title.
   const longestPossibleRouteCodeLength =
-    longestRouteCodeLength > 7 ? 3 : longestRouteCodeLength;
+    longestRouteCodeLength > 7
+      ? shortestRouteCodeLength
+      : longestRouteCodeLength;
 
   // How much taller letters are compared to width
   const fontHeightWidthRatio = 1.6;

--- a/src/util/getResources.ts
+++ b/src/util/getResources.ts
@@ -216,8 +216,10 @@ export const getRouteCodeColumnWidth = (departures, view, fontSize) => {
       const bLength = b?.trip?.route?.shortName?.length;
       return bLength === undefined || aLength > bLength ? aLength : bLength;
     }, shortestRouteCodeLength) || shortestRouteCodeLength; // Minimum length to allow space for the column title.
+  const longestPossibleRouteCodeLength =
+    longestRouteCodeLength > 7 ? 3 : longestRouteCodeLength;
 
   // How much taller letters are compared to width
   const fontHeightWidthRatio = 1.6;
-  return (fontSize / fontHeightWidthRatio) * longestRouteCodeLength;
+  return (fontSize / fontHeightWidthRatio) * longestPossibleRouteCodeLength;
 };


### PR DESCRIPTION
- Extra long line code causes a big gap when an icon was shown instead of the code, now limiting the length