### PR TITLE
Line code in config + line code column bug fix

### DIFF
--- a/src/defaultConfig.js
+++ b/src/defaultConfig.js
@@ -69,4 +69,5 @@ export default {
   map: {
     inUse: false,
   },
+  lineCodeMaxLength: 7, // Maximum length of line code to show in the monitor, values larger than 7 are not supported by horizontal layouts
 };

--- a/src/test/MonitorRow.test.tsx
+++ b/src/test/MonitorRow.test.tsx
@@ -22,6 +22,7 @@ const defaultProps = {
 
 const mockConfig = {
   useTilde: true,
+  lineCodeMaxLength: 7,
 };
 
 const withContext = prps => {
@@ -36,15 +37,15 @@ it('should render a row correctly', () => {
   const { container } = render(withContext(defaultProps));
   // destination
   expect(
-    container.getElementsByClassName('destination-row')[0].innerHTML,
+    container.getElementsByClassName('destination-row')[0]?.innerHTML,
   ).toEqual('Jyväskylä');
   // shortName
   expect(
-    container.getElementsByClassName('grid-col line')[0].innerHTML,
+    container.getElementsByClassName('grid-col line')[0]?.innerHTML,
   ).toEqual('123');
   // time,
   expect(
-    container.getElementsByClassName('grid-col time')[0].innerHTML.length,
+    container.getElementsByClassName('grid-col time')[0]?.innerHTML.length,
   ).toBeGreaterThan(0);
 });
 
@@ -62,7 +63,7 @@ it('should render a cancelled departure with the text cancelled', () => {
 
   const { container } = render(withContext(props));
   expect(
-    container.getElementsByClassName('cancelled-row')[0].innerHTML,
+    container.getElementsByClassName('cancelled-row')[0]?.innerHTML,
   ).toEqual('cancelled');
 });
 
@@ -80,10 +81,10 @@ it('should render a cancelled departure with alert icon and destination', () => 
   const { container } = render(withContext(props));
 
   expect(
-    container.getElementsByClassName('destination-row')[0].innerHTML,
+    container.getElementsByClassName('destination-row')[0]?.innerHTML,
   ).toEqual('Jyväskylä');
   expect(
-    container.getElementsByClassName('grid-col destination')[0].children[0]
+    container.getElementsByClassName('grid-col destination')[0]?.children[0]
       .nodeName,
   ).toEqual('svg');
 });
@@ -101,7 +102,7 @@ it('should do show tilde when realtime is off', () => {
 
   const { container } = render(withContext(props));
   expect(
-    container.getElementsByClassName('grid-col time')[0].innerHTML,
+    container.getElementsByClassName('grid-col time')[0]?.innerHTML,
   ).toContain('~');
 });
 
@@ -119,6 +120,6 @@ it('should show the stop code when a departure does not have a platform code', (
   const { container } = render(withContext(props));
 
   expect(
-    container.getElementsByClassName('grid-col code')[0].innerHTML,
+    container.getElementsByClassName('grid-col code')[0]?.innerHTML,
   ).toContain('H1234');
 });

--- a/src/ui/Monitor.tsx
+++ b/src/ui/Monitor.tsx
@@ -89,6 +89,7 @@ const Monitor: FC<IProps> = ({
     departures,
     view,
     fontSize,
+    config,
   );
   // The width and height of a vehicle icon.
   // For clarity icon is a bit bigger than text, except on tightened views where it is adjusted to fit narrower lines.

--- a/src/ui/MonitorRow.tsx
+++ b/src/ui/MonitorRow.tsx
@@ -248,22 +248,27 @@ const MonitorRow: FC<IProps> = ({
           'without-route-column': withoutRouteColumn,
         })}
       >
-        {!withoutRouteColumn && lineLen !== -1 && lineLen <= 7 && (
-          <div className={cx('grid-col line', `len${lineLen}`)}>
-            {line[0]}
-            {line.length > 1 && <span className="line-letter">{line[1]}</span>}
-          </div>
-        )}
-        {!withoutRouteColumn && (lineLen === -1 || lineLen > 7) && (
-          <div className={cx('grid-col line icon', `len${2}`)}>
-            <Icon
-              height={24}
-              width={24}
-              img={departure.vehicleMode || 'bus'}
-              color={config.colors.monitorBackground}
-            />
-          </div>
-        )}
+        {!withoutRouteColumn &&
+          lineLen !== -1 &&
+          lineLen <= config.lineCodeMaxLength && (
+            <div className={cx('grid-col line', `len${lineLen}`)}>
+              {line[0]}
+              {line.length > 1 && (
+                <span className="line-letter">{line[1]}</span>
+              )}
+            </div>
+          )}
+        {!withoutRouteColumn &&
+          (lineLen === -1 || lineLen > config.lineCodeMaxLength) && (
+            <div className={cx('grid-col line icon', `len${2}`)}>
+              <Icon
+                height={24}
+                width={24}
+                img={departure.vehicleMode || 'bus'}
+                color={config.colors.monitorBackground}
+              />
+            </div>
+          )}
         <div className="grid-col destination">
           {alertState && isCancelled ? (
             isTwoRow ? (

--- a/src/util/getResources.ts
+++ b/src/util/getResources.ts
@@ -208,18 +208,15 @@ export const getRouteCodeColumnWidth = (departures, view, fontSize, config) => {
     .concat(departures[1].slice(0, rightColumnCount));
 
   const minimumRouteCodeLength = 3; // Minimum length to allow space for the column title.
-  const longestRouteCodeLength =
-    departuresOnScreen?.reduce((a, b) => {
-      const maxALength =
-        a?.trip?.route?.shortName?.length <= config.lineCodeMaxLength
-          ? a?.trip?.route?.shortName?.length
-          : minimumRouteCodeLength;
-      const maxBLength =
-        b?.trip?.route?.shortName?.length <= config.lineCodeMaxLength
-          ? b?.trip?.route?.shortName?.length
-          : minimumRouteCodeLength;
-      return maxALength > maxBLength ? a : b;
-    }).trip?.route?.shortName?.length || minimumRouteCodeLength;
+
+  const lengthValues = departuresOnScreen.map(
+    departure => departure.trip?.route?.shortName?.length,
+  );
+
+  const longestRouteCodeLength = lengthValues.reduce(
+    (a, b) => (!b || b > config.lineCodeMaxLength || a > b ? a : b),
+    minimumRouteCodeLength,
+  );
 
   // How much taller letters are compared to width
   const fontHeightWidthRatio = 1.6;

--- a/src/util/getResources.ts
+++ b/src/util/getResources.ts
@@ -200,28 +200,27 @@ export function getLoginUri(configName) {
   }
 }
 
-export const getRouteCodeColumnWidth = (departures, view, fontSize) => {
+export const getRouteCodeColumnWidth = (departures, view, fontSize, config) => {
   const { leftColumnCount, rightColumnCount } = getLayout(view.layout);
 
   const departuresOnScreen = departures[0]
     .slice(0, leftColumnCount)
     .concat(departures[1].slice(0, rightColumnCount));
 
-  const shortestRouteCodeLength = 3; // The line code heading still fits
-  const longestRouteCodeLength =
-    departuresOnScreen?.reduce((a, b) => {
-      const aLengthValue = a?.trip?.route?.shortName?.length;
-      const aLength =
-        aLengthValue !== undefined && aLengthValue !== null ? aLengthValue : a;
-      const bLength = b?.trip?.route?.shortName?.length;
-      return bLength === undefined || aLength > bLength ? aLength : bLength;
-    }, shortestRouteCodeLength) || shortestRouteCodeLength; // Minimum length to allow space for the column title.
-  const longestPossibleRouteCodeLength =
-    longestRouteCodeLength > 7 // over 7 characters causes the icon to be shown
-      ? shortestRouteCodeLength
-      : longestRouteCodeLength;
+  const minimumRouteCodeLength = 3; // Minimum length to allow space for the column title.
+  const longestRouteCodeLength = departuresOnScreen?.reduce((a, b) => {
+    const maxALength =
+      a?.trip?.route?.shortName?.length <= config.lineCodeMaxLength
+        ? a?.trip?.route?.shortName?.length
+        : minimumRouteCodeLength;
+    const maxBLength =
+      b?.trip?.route?.shortName?.length <= config.lineCodeMaxLength
+        ? b?.trip?.route?.shortName?.length
+        : minimumRouteCodeLength;
+    return maxALength > maxBLength ? a : b;
+  }, minimumRouteCodeLength).trip?.route?.shortName?.length;
 
   // How much taller letters are compared to width
   const fontHeightWidthRatio = 1.6;
-  return (fontSize / fontHeightWidthRatio) * longestPossibleRouteCodeLength;
+  return (fontSize / fontHeightWidthRatio) * longestRouteCodeLength;
 };

--- a/src/util/getResources.ts
+++ b/src/util/getResources.ts
@@ -208,17 +208,18 @@ export const getRouteCodeColumnWidth = (departures, view, fontSize, config) => {
     .concat(departures[1].slice(0, rightColumnCount));
 
   const minimumRouteCodeLength = 3; // Minimum length to allow space for the column title.
-  const longestRouteCodeLength = departuresOnScreen?.reduce((a, b) => {
-    const maxALength =
-      a?.trip?.route?.shortName?.length <= config.lineCodeMaxLength
-        ? a?.trip?.route?.shortName?.length
-        : minimumRouteCodeLength;
-    const maxBLength =
-      b?.trip?.route?.shortName?.length <= config.lineCodeMaxLength
-        ? b?.trip?.route?.shortName?.length
-        : minimumRouteCodeLength;
-    return maxALength > maxBLength ? a : b;
-  }, minimumRouteCodeLength).trip?.route?.shortName?.length;
+  const longestRouteCodeLength =
+    departuresOnScreen?.reduce((a, b) => {
+      const maxALength =
+        a?.trip?.route?.shortName?.length <= config.lineCodeMaxLength
+          ? a?.trip?.route?.shortName?.length
+          : minimumRouteCodeLength;
+      const maxBLength =
+        b?.trip?.route?.shortName?.length <= config.lineCodeMaxLength
+          ? b?.trip?.route?.shortName?.length
+          : minimumRouteCodeLength;
+      return maxALength > maxBLength ? a : b;
+    }).trip?.route?.shortName?.length || minimumRouteCodeLength;
 
   // How much taller letters are compared to width
   const fontHeightWidthRatio = 1.6;


### PR DESCRIPTION
- The max length of the line code is defined in config 
- There was a bug where the line code calculation assumed all line codes were over long if one was, and the codes that were still displayed got squashed in to minimum space. 