### PR TITLE
DT-6387 map zoom animation off

### DIFF
--- a/src/ui/monitorMap.tsx
+++ b/src/ui/monitorMap.tsx
@@ -122,7 +122,12 @@ const MonitorMap: FC<IProps> = ({
       : mapSettings.bounds[0];
     const zoom = mapSettings.zoom ? mapSettings.zoom : 14;
     if (!map) {
-      setMap(L.map('map', { zoomControl: false }).setView(center, zoom));
+      setMap(
+        L.map('map', { zoomControl: false, zoomAnimation: false }).setView(
+          center,
+          zoom,
+        ),
+      );
     } else {
       monitorAPI.getMapSettings(lang).then((r: string) => {
         L.tileLayer(r, {


### PR DESCRIPTION
- map shouldn't zoom when it appears on the monitor