### PR TITLE
DT-6627 When alerts are removed the stopmonitor may crash

### DIFF
--- a/src/ui/MonitorAlertRowStatic.tsx
+++ b/src/ui/MonitorAlertRowStatic.tsx
@@ -34,15 +34,13 @@ const MonitorAlertRowStatic: FC<IProps> = ({
     return () => clearTimeout(id);
   }, [current]);
 
+  const alertObject = alerts[alertIndex] || alerts[0];
   const alert =
     getServiceAlertDescription(
-      alerts[alertIndex],
+      alertObject,
       languages[current % languages.length],
     ) ||
-    getServiceAlertHeader(
-      alerts[alertIndex],
-      languages[current % languages.length],
-    );
+    getServiceAlertHeader(alertObject, languages[current % languages.length]);
 
   return (
     <div className={cx('grid-row', 'alert static')}>


### PR DESCRIPTION
- Ensure an alert exists before attempting to show it. (The index may be set based on an out of date set of alerts)
- Test by having multiple alerts which disapper at different times.