### PR TITLE
AB#128 Fix a bug where date separator was only shown on the left side

### DIFF
--- a/src/ui/MonitorRowContainer.tsx
+++ b/src/ui/MonitorRowContainer.tsx
@@ -53,8 +53,10 @@ const MonitorRowContainer: FC<IProps> = ({
   const currentDay = setDate(0);
   const nextDay = setDate(1);
   const nextDayDepartureIndexLeft = departuresLeft
-    .slice(0, leftColumnCount)
-    .findIndex(departure => departure?.serviceDay === nextDay.getTime() / 1000);
+    .slice(0, leftColumnCount + rightColumnCount)
+    .findIndex(
+      (departure) => departure?.serviceDay === nextDay.getTime() / 1000
+    );
 
   if (nextDayDepartureIndexLeft !== -1) {
     departuresLeft.splice(nextDayDepartureIndexLeft, 0, null);
@@ -144,6 +146,7 @@ const MonitorRowContainer: FC<IProps> = ({
       ) {
         const departure =
           i !== nextDayDepartureIndexLeft ? departuresLeft[i] : null;
+
         rightColumn.push(
           <MonitorRow
             key={
@@ -167,7 +170,7 @@ const MonitorRowContainer: FC<IProps> = ({
             currentLang={currentLang}
             showMinutes={showMinutes || 0}
             withoutRouteColumn={withoutRouteColumn}
-          />,
+          />
         );
       }
     } else {

--- a/src/ui/MonitorRowContainer.tsx
+++ b/src/ui/MonitorRowContainer.tsx
@@ -1,12 +1,12 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import React, { FC } from "react";
-import MonitorRow, { IDeparture } from "./MonitorRow";
-import cx from "classnames";
-import { formatDate, setDate, formattedDateTimeFromSeconds } from "../time";
-import { getLayout } from "../util/getResources";
-import { IClosedStop } from "../util/Interfaces";
-import { useTranslation } from "react-i18next";
-import { stoptimeSpecificDepartureId } from "../util/monitorUtils";
+import React, { FC } from 'react';
+import MonitorRow, { IDeparture } from './MonitorRow';
+import cx from 'classnames';
+import { formatDate, setDate, formattedDateTimeFromSeconds } from '../time';
+import { getLayout } from '../util/getResources';
+import { IClosedStop } from '../util/Interfaces';
+import { useTranslation } from 'react-i18next';
+import { stoptimeSpecificDepartureId } from '../util/monitorUtils';
 
 interface IProps {
   viewId: number;
@@ -24,14 +24,14 @@ interface IProps {
   closedStopViews: Array<IClosedStop>;
   preview: boolean;
 }
-const hasColumn = (value) => value === false;
+const hasColumn = value => value === false;
 
 const isSameDate = (departure: IDeparture, nextDay) => {
   if (!departure) {
     return false;
   }
   const depDate = new Date(
-    (departure.realtimeDeparture + departure.serviceDay) * 1000
+    (departure.realtimeDeparture + departure.serviceDay) * 1000,
   );
 
   return depDate.getDate() === nextDay.getDate();
@@ -46,7 +46,7 @@ const formatSingleColumnData = (
   nRows: number,
   date: number,
   departuresIndex: number,
-  currentLang: string
+  currentLang: string,
 ) => {
   let lastWasDayDivider = false;
   const rows = Array(nRows)
@@ -55,7 +55,7 @@ const formatSingleColumnData = (
       const departure = departures[departuresIndex];
       const isFirst = rowIndex === 0 || lastWasDayDivider;
       const isLastRow = rowIndex === nRows - 1;
-      if (!!departure) {
+      if (departure) {
         if (isSameDate(departure, setDate(date))) {
           departuresIndex++;
           lastWasDayDivider = false;
@@ -84,7 +84,7 @@ const formatSingleDisplayData = (
   departures: IDeparture[],
   leftColumnSize: number,
   rightColumnSize: number,
-  currentLang: string
+  currentLang: string,
 ) => {
   const {
     rows: leftRows,
@@ -96,7 +96,7 @@ const formatSingleDisplayData = (
     rightColumnSize,
     date as number,
     departuresIndex as number,
-    currentLang
+    currentLang,
   );
 
   return { leftRows, rightRows };
@@ -108,21 +108,21 @@ const formatMultiDisplayData = (
   departuresRight: IDeparture[],
   leftColumnSize: number,
   rightColumnSize: number,
-  currentLang: string
+  currentLang: string,
 ) => {
   const { rows: leftRows } = formatSingleColumnData(
     departuresLeft,
     leftColumnSize,
     0,
     0,
-    currentLang
+    currentLang,
   );
   const { rows: rightRows } = formatSingleColumnData(
     departuresRight,
     rightColumnSize,
     0,
     0,
-    currentLang
+    currentLang,
   );
   return { leftRows, rightRows };
 };
@@ -144,13 +144,13 @@ const MonitorRowContainer: FC<IProps> = ({
   preview,
 }) => {
   const [t] = useTranslation();
-  const DATE_FORMAT = "dd.MM.yyyy HH:mm";
+  const DATE_FORMAT = 'dd.MM.yyyy HH:mm';
   const { leftColumnCount, rightColumnCount, isMultiDisplay, tighten } =
     getLayout(layout);
 
   const isTighten = tighten !== undefined;
   const hasRouteColumn = [];
-  leftStops.forEach((s) => {
+  leftStops.forEach(s => {
     if (s.settings && s.settings.showRouteColumn !== undefined) {
       hasRouteColumn.push(s.settings.showRouteColumn);
     } else {
@@ -170,13 +170,13 @@ const MonitorRowContainer: FC<IProps> = ({
         departuresRight,
         leftColumnCountWithAlerts,
         rightColumnCount,
-        currentLang
+        currentLang,
       )
     : formatSingleDisplayData(
         departuresLeft,
         leftColumnCountWithAlerts,
         rightColumnCount,
-        currentLang
+        currentLang,
       );
 
   const leftColumn = leftRows.map(({ departure, dayDivider, isFirst }, i) => (
@@ -228,14 +228,14 @@ const MonitorRowContainer: FC<IProps> = ({
   ));
   const headers = (columns, stops) => {
     let withStopCode = false;
-    stops.forEach((s) => {
+    stops.forEach(s => {
       if (s.settings?.showStopNumber) {
         withStopCode = true;
       }
     });
 
     const hasRouteColumn = [];
-    stops.forEach((s) => {
+    stops.forEach(s => {
       if (s.settings && s.settings.showRouteColumn !== undefined) {
         hasRouteColumn.push(s.settings.showRouteColumn);
       } else {
@@ -251,91 +251,91 @@ const MonitorRowContainer: FC<IProps> = ({
     return (
       <div
         className={cx(
-          "grid-headers",
+          'grid-headers',
           `rows${isTighten ? tighten[0] : columns}`,
           {
             tightened: isTighten,
             portrait: !isLandscape,
-            "two-cols": withTwoColumns,
-          }
+            'two-cols': withTwoColumns,
+          },
         )}
       >
         <div
           className={cx(
-            "grid-row",
-            { "with-stop-code": withStopCode },
-            { "without-route-column": withoutRouteColumn }
+            'grid-row',
+            { 'with-stop-code': withStopCode },
+            { 'without-route-column': withoutRouteColumn },
           )}
         >
           {!withoutRouteColumn && (
-            <div className={cx("grid-header", "line")}>
-              {t("lineId", { lng: currentLang })}
+            <div className={cx('grid-header', 'line')}>
+              {t('lineId', { lng: currentLang })}
             </div>
           )}
-          <div className={cx("grid-header", "destination")}>
-            {t("destination", { lng: currentLang })}
+          <div className={cx('grid-header', 'destination')}>
+            {t('destination', { lng: currentLang })}
           </div>
           {withStopCode && (
-            <div className={cx("grid-header", "platform-code")}>
-              {t("platform-or-stop", { lng: currentLang })}
+            <div className={cx('grid-header', 'platform-code')}>
+              {t('platform-or-stop', { lng: currentLang })}
             </div>
           )}
-          <div className={cx("grid-header", "time")}>
-            {t("departureTime", { lng: currentLang })}
+          <div className={cx('grid-header', 'time')}>
+            {t('departureTime', { lng: currentLang })}
           </div>
         </div>
       </div>
     );
   };
 
-  const closedStopIndex = closedStopViews.findIndex((s) => s.viewId === viewId);
+  const closedStopIndex = closedStopViews.findIndex(s => s.viewId === viewId);
   const isClosedStopOnLeft =
     closedStopIndex !== -1 &&
-    closedStopViews[closedStopIndex].column === "left";
+    closedStopViews[closedStopIndex].column === 'left';
   const isClosedStopOnRight =
     closedStopIndex !== -1 &&
-    closedStopViews[closedStopIndex].column === "right";
+    closedStopViews[closedStopIndex].column === 'right';
 
   const noKnownDeparturesLeft =
     !departuresLeft.length &&
-    !leftStops.every((s) => s.settings?.allRoutesHidden);
+    !leftStops.every(s => s.settings?.allRoutesHidden);
   const noKnownDeparturesRight =
     !departuresRight.length &&
-    !rightStops.every((s) => s.settings?.allRoutesHidden);
+    !rightStops.every(s => s.settings?.allRoutesHidden);
 
   return (
     <div
-      className={cx("monitor-container", {
+      className={cx('monitor-container', {
         preview: preview,
         portrait: !isLandscape,
-        "two-cols": withTwoColumns,
+        'two-cols': withTwoColumns,
         tightened: isTighten,
       })}
     >
       <div
-        className={cx("grid", {
+        className={cx('grid', {
           portrait: !isLandscape,
-          "two-cols": withTwoColumns,
+          'two-cols': withTwoColumns,
         })}
       >
         {headers(leftColumnCount, leftStops)}
         {isTighten && departuresLeft.length > 0 && (
           <div
-            className={cx("grid-rows portrait tightened", `rows${tighten[0]}`)}
+            className={cx('grid-rows portrait tightened', `rows${tighten[0]}`)}
           >
             {leftColumn.slice(0, tighten[0])}
           </div>
         )}
         <div
           className={cx(
-            "grid-rows",
+            'grid-rows',
             `rows${isTighten ? tighten[1] : leftColumnCount}`,
             {
               portrait: !isLandscape,
-              "two-cols": withTwoColumns,
+              'two-cols': withTwoColumns,
               tightened: isTighten,
-              "no-departures": isClosedStopOnLeft || noKnownDeparturesLeft,
-            }
+              'no-departures': isClosedStopOnLeft || noKnownDeparturesLeft,
+            },
           )}
         >
           {!isClosedStopOnLeft && !noKnownDeparturesLeft ? (
@@ -343,25 +343,25 @@ const MonitorRowContainer: FC<IProps> = ({
           ) : (
             <div className="no-departures-text-container">
               <div
-                className={cx("no-departures-text", {
-                  "closed-stop": isClosedStopOnLeft,
+                className={cx('no-departures-text', {
+                  'closed-stop': isClosedStopOnLeft,
                 })}
               >
                 {isClosedStopOnLeft
-                  ? t("closedStopWithRange", {
+                  ? t('closedStopWithRange', {
                       lng: currentLang,
                       name: closedStopViews[closedStopIndex].name,
                       code: closedStopViews[closedStopIndex].code,
                       startTime: formattedDateTimeFromSeconds(
                         closedStopViews[closedStopIndex].startTime,
-                        DATE_FORMAT
+                        DATE_FORMAT,
                       ),
                       endTime: formattedDateTimeFromSeconds(
                         closedStopViews[closedStopIndex].endTime,
-                        DATE_FORMAT
+                        DATE_FORMAT,
                       ),
                     })
-                  : t("no-departures", { lng: currentLang })}
+                  : t('no-departures', { lng: currentLang })}
               </div>
             </div>
           )}
@@ -372,15 +372,15 @@ const MonitorRowContainer: FC<IProps> = ({
         <>
           <div className="divider" />
           {true && (
-            <div className={cx("grid", { "two-cols": withTwoColumns })}>
+            <div className={cx('grid', { 'two-cols': withTwoColumns })}>
               {headers(
                 rightColumnCount,
-                isMultiDisplay ? rightStops : leftStops
+                isMultiDisplay ? rightStops : leftStops,
               )}
               <div
-                className={cx("grid-rows", `rows${rightColumnCount}`, {
-                  "two-cols": withTwoColumns,
-                  "no-departures":
+                className={cx('grid-rows', `rows${rightColumnCount}`, {
+                  'two-cols': withTwoColumns,
+                  'no-departures':
                     isClosedStopOnRight || noKnownDeparturesRight,
                 })}
               >
@@ -388,25 +388,25 @@ const MonitorRowContainer: FC<IProps> = ({
                   <>
                     <div className="no-departures-text-container">
                       <div
-                        className={cx("no-departures-text", {
-                          "closed-stop": isClosedStopOnRight,
+                        className={cx('no-departures-text', {
+                          'closed-stop': isClosedStopOnRight,
                         })}
                       >
                         {isClosedStopOnRight
-                          ? t("closedStopWithRange", {
+                          ? t('closedStopWithRange', {
                               lng: currentLang,
                               name: closedStopViews[closedStopIndex].name,
                               code: closedStopViews[closedStopIndex].code,
                               startTime: formattedDateTimeFromSeconds(
                                 closedStopViews[closedStopIndex].startTime,
-                                DATE_FORMAT
+                                DATE_FORMAT,
                               ),
                               endTime: formattedDateTimeFromSeconds(
                                 closedStopViews[closedStopIndex].endTime,
-                                DATE_FORMAT
+                                DATE_FORMAT,
                               ),
                             })
-                          : t("no-departures", { lng: currentLang })}
+                          : t('no-departures', { lng: currentLang })}
                       </div>
                     </div>
                     {alertComponent && <div className="alert-padding"></div>}

--- a/src/ui/MonitorRowContainer.tsx
+++ b/src/ui/MonitorRowContainer.tsx
@@ -42,49 +42,46 @@ const isSameDate = (departure: IDeparture, nextDay) => {
   Formats rows for a single column
   Returns a list of rows, date of last row and the index of remaining departures
 */
-const singleCol = (
+const formatSingleColumnData = (
   departures: IDeparture[],
   nRows: number,
   date: number,
   departuresIndex: number,
   currentLang: string
 ) => {
+  let lastWasDayDivider = false;
   const rows = Array(nRows)
     .fill(null)
     .map((_, rowIndex) => {
       const departure = departures[departuresIndex];
-      if (departure) {
+      const isFirst = rowIndex === 0 || lastWasDayDivider;
+      const isLastRow = rowIndex === nRows - 1;
+      if (!!departure) {
         if (isSameDate(departure, setDate(date))) {
           departuresIndex++;
-          return { departure, dayDivider: null, empty: false };
-        } else {
+          lastWasDayDivider = false;
+          return { departure, dayDivider: null, isFirst };
+        } else if (!isLastRow) {
           // if next departure is on a different day, add day divider
           // unless it's the last row of the column
-          if (!(rowIndex === nRows - 1)) {
-            date++;
-            return {
-              departure: null,
-              dayDivider: formatDate(setDate(date), currentLang),
-              empty: false,
-            };
-          } else {
-            return {
-              departure: null,
-              dayDivider: null,
-              empty: true,
-            };
-          }
+          date++;
+          lastWasDayDivider = true;
+          return {
+            departure: null,
+            dayDivider: formatDate(setDate(date), currentLang),
+            isFirst,
+          };
         }
-      } else {
-        // if no more departures, return empty rows
-        return { departure: null, dayDivider: null, empty: true };
       }
+      // if no more departures, return empty rows
+      lastWasDayDivider = false;
+      return { departure: null, dayDivider: null, isFirst };
     });
   return { rows, date, departuresIndex };
 };
 
 // Processess rows for a monitor containing a single stop display
-const formatSingleDisplay = (
+const formatSingleDisplayData = (
   departures: IDeparture[],
   leftColumnSize: number,
   rightColumnSize: number,
@@ -94,43 +91,41 @@ const formatSingleDisplay = (
     rows: leftRows,
     date,
     departuresIndex,
-  } = singleCol(departures, leftColumnSize, 0, 0, currentLang);
-  //console.log(date, index)
-  const { rows: rightRows } = singleCol(
+  } = formatSingleColumnData(departures, leftColumnSize, 0, 0, currentLang);
+  const { rows: rightRows } = formatSingleColumnData(
     departures,
     rightColumnSize,
     date as number,
     departuresIndex as number,
     currentLang
   );
-  //console.log(rightRows)
 
-  return [leftRows, rightRows];
+  return { leftRows, rightRows };
 };
 
 // Processes rows for a multi display monitor (where right side has dedicated departures)
-const formatMultiDisplay = (
+const formatMultiDisplayData = (
   departuresLeft: IDeparture[],
   departuresRight: IDeparture[],
   leftColumnSize: number,
   rightColumnSize: number,
   currentLang: string
 ) => {
-  const { rows: leftRows } = singleCol(
+  const { rows: leftRows } = formatSingleColumnData(
     departuresLeft,
     leftColumnSize,
     0,
     0,
-    currentLang,
+    currentLang
   );
-  const { rows: rightRows } = singleCol(
+  const { rows: rightRows } = formatSingleColumnData(
     departuresRight,
     rightColumnSize,
     0,
     0,
-    currentLang,
+    currentLang
   );
-  return [leftRows, rightRows];
+  return { leftRows, rightRows };
 };
 
 const MonitorRowContainer: FC<IProps> = ({
@@ -169,28 +164,27 @@ const MonitorRowContainer: FC<IProps> = ({
   if (alertComponent && layout < 12) {
     leftColumnCountWithAlerts -= alertRowSpan;
   }
-  //console.log(departuresLeft);
-  const [leftRows, rightRows] = isMultiDisplay
-    ? formatMultiDisplay(
+
+  const { leftRows, rightRows } = isMultiDisplay
+    ? formatMultiDisplayData(
         departuresLeft,
         departuresRight,
-        leftColumnCount,
+        leftColumnCountWithAlerts,
         rightColumnCount,
         currentLang
       )
-    : formatSingleDisplay(
+    : formatSingleDisplayData(
         departuresLeft,
-        leftColumnCount,
+        leftColumnCountWithAlerts,
         rightColumnCount,
         currentLang
       );
-  //console.log(leftRows, rightRows);
 
-  const leftColumn = leftRows.map(({ departure, dayDivider, empty }, i) => (
+  const leftColumn = leftRows.map(({ departure, dayDivider, isFirst }, i) => (
     <MonitorRow
       key={departure ? stoptimeSpecificDepartureId(departure) : `row_l${i}`}
       departure={departure}
-      isFirst={i === 0}
+      isFirst={isFirst}
       showVia={
         layout < 4 ||
         layout === 12 ||
@@ -210,11 +204,11 @@ const MonitorRowContainer: FC<IProps> = ({
     />
   ));
 
-  const rightColumn = rightRows.map(({ departure, dayDivider, empty }, i) => (
+  const rightColumn = rightRows.map(({ departure, dayDivider, isFirst }, i) => (
     <MonitorRow
       key={departure ? stoptimeSpecificDepartureId(departure) : `row_r${i}`}
       departure={departure}
-      isFirst={i === 0}
+      isFirst={isFirst}
       showVia={
         layout < 4 ||
         layout === 12 ||

--- a/src/ui/MonitorRowContainer.tsx
+++ b/src/ui/MonitorRowContainer.tsx
@@ -7,7 +7,6 @@ import { getLayout } from "../util/getResources";
 import { IClosedStop } from "../util/Interfaces";
 import { useTranslation } from "react-i18next";
 import { stoptimeSpecificDepartureId } from "../util/monitorUtils";
-import { departure } from "../test/data/monitor";
 
 interface IProps {
   viewId: number;

--- a/src/ui/MonitorRowContainer.tsx
+++ b/src/ui/MonitorRowContainer.tsx
@@ -1,12 +1,13 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import React, { FC } from 'react';
-import MonitorRow, { IDeparture } from './MonitorRow';
-import cx from 'classnames';
-import { formatDate, setDate, formattedDateTimeFromSeconds } from '../time';
-import { getLayout } from '../util/getResources';
-import { IClosedStop } from '../util/Interfaces';
-import { useTranslation } from 'react-i18next';
-import { stoptimeSpecificDepartureId } from '../util/monitorUtils';
+import React, { FC } from "react";
+import MonitorRow, { IDeparture } from "./MonitorRow";
+import cx from "classnames";
+import { formatDate, setDate, formattedDateTimeFromSeconds } from "../time";
+import { getLayout } from "../util/getResources";
+import { IClosedStop } from "../util/Interfaces";
+import { useTranslation } from "react-i18next";
+import { stoptimeSpecificDepartureId } from "../util/monitorUtils";
+import { departure } from "../test/data/monitor";
 
 interface IProps {
   viewId: number;
@@ -24,7 +25,113 @@ interface IProps {
   closedStopViews: Array<IClosedStop>;
   preview: boolean;
 }
-const hasColumn = value => value === false;
+const hasColumn = (value) => value === false;
+
+const isSameDate = (departure: IDeparture, nextDay) => {
+  if (!departure) {
+    return false;
+  }
+  const depDate = new Date(
+    (departure.realtimeDeparture + departure.serviceDay) * 1000
+  );
+
+  return depDate.getDate() === nextDay.getDate();
+};
+
+/*
+  Formats rows for a single column
+  Returns a list of rows, date of last row and the index of remaining departures
+*/
+const singleCol = (
+  departures: IDeparture[],
+  nRows: number,
+  date: number,
+  departuresIndex: number,
+  currentLang: string
+) => {
+  const rows = Array(nRows)
+    .fill(null)
+    .map((_, rowIndex) => {
+      const departure = departures[departuresIndex];
+      if (departure) {
+        if (isSameDate(departure, setDate(date))) {
+          departuresIndex++;
+          return { departure, dayDivider: null, empty: false };
+        } else {
+          // if next departure is on a different day, add day divider
+          // unless it's the last row of the column
+          if (!(rowIndex === nRows - 1)) {
+            date++;
+            return {
+              departure: null,
+              dayDivider: formatDate(setDate(date), currentLang),
+              empty: false,
+            };
+          } else {
+            return {
+              departure: null,
+              dayDivider: null,
+              empty: true,
+            };
+          }
+        }
+      } else {
+        // if no more departures, return empty rows
+        return { departure: null, dayDivider: null, empty: true };
+      }
+    });
+  return { rows, date, departuresIndex };
+};
+
+// Processess rows for a monitor containing a single stop display
+const formatSingleDisplay = (
+  departures: IDeparture[],
+  leftColumnSize: number,
+  rightColumnSize: number,
+  currentLang: string
+) => {
+  const {
+    rows: leftRows,
+    date,
+    departuresIndex,
+  } = singleCol(departures, leftColumnSize, 0, 0, currentLang);
+  //console.log(date, index)
+  const { rows: rightRows } = singleCol(
+    departures,
+    rightColumnSize,
+    date as number,
+    departuresIndex as number,
+    currentLang
+  );
+  //console.log(rightRows)
+
+  return [leftRows, rightRows];
+};
+
+// Processes rows for a multi display monitor (where right side has dedicated departures)
+const formatMultiDisplay = (
+  departuresLeft: IDeparture[],
+  departuresRight: IDeparture[],
+  leftColumnSize: number,
+  rightColumnSize: number,
+  currentLang: string
+) => {
+  const { rows: leftRows } = singleCol(
+    departuresLeft,
+    leftColumnSize,
+    0,
+    0,
+    currentLang,
+  );
+  const { rows: rightRows } = singleCol(
+    departuresRight,
+    rightColumnSize,
+    0,
+    0,
+    currentLang,
+  );
+  return [leftRows, rightRows];
+};
 
 const MonitorRowContainer: FC<IProps> = ({
   viewId,
@@ -43,56 +150,13 @@ const MonitorRowContainer: FC<IProps> = ({
   preview,
 }) => {
   const [t] = useTranslation();
-  const DATE_FORMAT = 'dd.MM.yyyy HH:mm';
+  const DATE_FORMAT = "dd.MM.yyyy HH:mm";
   const { leftColumnCount, rightColumnCount, isMultiDisplay, tighten } =
     getLayout(layout);
 
-  const leftColumn = [];
-  const rightColumn = [];
-
-  const currentDay = setDate(0);
-  const nextDay = setDate(1);
-  const nextDayDepartureIndexLeft = departuresLeft
-    .slice(0, leftColumnCount + rightColumnCount)
-    .findIndex(
-      (departure) => departure?.serviceDay === nextDay.getTime() / 1000
-    );
-
-  if (nextDayDepartureIndexLeft !== -1) {
-    departuresLeft.splice(nextDayDepartureIndexLeft, 0, null);
-  }
-
-  let currentDayDepartureIndexRight = -1;
-  let nextDayDepartureIndexRight = departuresRight
-    .slice(0, rightColumnCount)
-    .findIndex(departure => departure.serviceDay === nextDay.getTime() / 1000);
-
-  const currentDayDeparturesRight = departuresRight
-    .slice(0, rightColumnCount)
-    .filter(departure => departure.serviceDay === currentDay.getTime() / 1000);
-  const nextDayDeparturesRight = departuresRight
-    .slice(0, rightColumnCount)
-    .filter(departure => departure.serviceDay === nextDay.getTime() / 1000);
-
-  let rowCountRight = currentDayDeparturesRight.length;
-  if (nextDayDeparturesRight.length !== 0) {
-    rowCountRight += nextDayDeparturesRight.length + 1;
-  }
-
-  if (currentDayDepartureIndexRight !== -1) {
-    if (rowCountRight < rightColumnCount || rightColumnCount !== 0) {
-      nextDayDepartureIndexRight += departuresRight.length === 0 ? 0 : 1;
-      if (currentDayDeparturesRight.length > 0) {
-        currentDayDepartureIndexRight = 0;
-        departuresRight.splice(0, 0, null);
-      }
-    }
-    departuresRight.splice(nextDayDepartureIndexRight, 0, null);
-  }
-
   const isTighten = tighten !== undefined;
   const hasRouteColumn = [];
-  leftStops.forEach(s => {
+  leftStops.forEach((s) => {
     if (s.settings && s.settings.showRouteColumn !== undefined) {
       hasRouteColumn.push(s.settings.showRouteColumn);
     } else {
@@ -105,113 +169,80 @@ const MonitorRowContainer: FC<IProps> = ({
   if (alertComponent && layout < 12) {
     leftColumnCountWithAlerts -= alertRowSpan;
   }
-  for (let i = 0; i < leftColumnCountWithAlerts; i++) {
-    const departure =
-      i !== nextDayDepartureIndexLeft ? departuresLeft[i] : null;
-    leftColumn.push(
-      <MonitorRow
-        key={departure ? stoptimeSpecificDepartureId(departure) : `row_l${i}`}
-        departure={departure}
-        isFirst={i === 0 || i - 1 === nextDayDepartureIndexLeft}
-        showVia={
-          layout < 4 ||
-          layout === 12 ||
-          (layout === 16 && i < 4) ||
-          leftColumnCount === 4
-        }
-        isTwoRow={
-          leftColumnCount === 4 || layout === 12 || (layout === 16 && i < 4)
-        }
-        withTwoColumns={withTwoColumns}
-        alertState={alertState}
-        stops={leftStops}
-        currentLang={currentLang}
-        dayForDivider={
-          i === nextDayDepartureIndexLeft
-            ? formatDate(nextDay, currentLang)
-            : undefined
-        }
-        showMinutes={showMinutes || 0}
-        withoutRouteColumn={withoutRouteColumn}
-      />,
-    );
-  }
+  //console.log(departuresLeft);
+  const [leftRows, rightRows] = isMultiDisplay
+    ? formatMultiDisplay(
+        departuresLeft,
+        departuresRight,
+        leftColumnCount,
+        rightColumnCount,
+        currentLang
+      )
+    : formatSingleDisplay(
+        departuresLeft,
+        leftColumnCount,
+        rightColumnCount,
+        currentLang
+      );
+  //console.log(leftRows, rightRows);
 
-  if (isLandscape) {
-    if (!isMultiDisplay) {
-      for (
-        let i = leftColumnCountWithAlerts;
-        i < leftColumnCountWithAlerts + rightColumnCount;
-        i++
-      ) {
-        const departure =
-          i !== nextDayDepartureIndexLeft ? departuresLeft[i] : null;
+  const leftColumn = leftRows.map(({ departure, dayDivider, empty }, i) => (
+    <MonitorRow
+      key={departure ? stoptimeSpecificDepartureId(departure) : `row_l${i}`}
+      departure={departure}
+      isFirst={i === 0}
+      showVia={
+        layout < 4 ||
+        layout === 12 ||
+        (layout === 16 && i < 4) ||
+        leftColumnCount === 4
+      }
+      isTwoRow={
+        leftColumnCount === 4 || layout === 12 || (layout === 16 && i < 4)
+      }
+      withTwoColumns={withTwoColumns}
+      alertState={alertState}
+      stops={leftStops}
+      currentLang={currentLang}
+      dayForDivider={dayDivider}
+      showMinutes={showMinutes || 0}
+      withoutRouteColumn={withoutRouteColumn}
+    />
+  ));
 
-        rightColumn.push(
-          <MonitorRow
-            key={
-              departure ? stoptimeSpecificDepartureId(departure) : `row_c${i}`
-            }
-            departure={departure}
-            isFirst={
-              i === leftColumnCountWithAlerts ||
-              i - 1 === nextDayDepartureIndexLeft
-            }
-            isTwoRow={rightColumnCount === 4 || layout === 12}
-            stops={leftStops}
-            showVia={rightColumnCount === 4}
-            withTwoColumns={withTwoColumns}
-            alertState={alertState}
-            dayForDivider={
-              i === nextDayDepartureIndexLeft
-                ? formatDate(nextDay, currentLang)
-                : undefined
-            }
-            currentLang={currentLang}
-            showMinutes={showMinutes || 0}
-            withoutRouteColumn={withoutRouteColumn}
-          />
-        );
+  const rightColumn = rightRows.map(({ departure, dayDivider, empty }, i) => (
+    <MonitorRow
+      key={departure ? stoptimeSpecificDepartureId(departure) : `row_r${i}`}
+      departure={departure}
+      isFirst={i === 0}
+      showVia={
+        layout < 4 ||
+        layout === 12 ||
+        (layout === 16 && i < 4) ||
+        leftColumnCount === 4
       }
-    } else {
-      for (let i = 0; i < rightColumnCount; i++) {
-        const departure =
-          i !== nextDayDepartureIndexRight ? departuresRight[i] : null;
-        rightColumn.push(
-          <MonitorRow
-            key={
-              departure ? stoptimeSpecificDepartureId(departure) : `row_r${i}`
-            }
-            departure={departure}
-            isTwoRow={rightColumnCount === 4 || layout === 12}
-            stops={rightStops}
-            isFirst={i === 0 || i - 1 === nextDayDepartureIndexRight}
-            showVia={rightColumnCount === 4}
-            withTwoColumns={withTwoColumns}
-            alertState={alertState}
-            dayForDivider={
-              i === nextDayDepartureIndexRight
-                ? formatDate(nextDay, currentLang)
-                : undefined
-            }
-            currentLang={currentLang}
-            showMinutes={showMinutes || 0}
-            withoutRouteColumn={withoutRouteColumn}
-          />,
-        );
+      isTwoRow={
+        leftColumnCount === 4 || layout === 12 || (layout === 16 && i < 4)
       }
-    }
-  }
+      withTwoColumns={withTwoColumns}
+      alertState={alertState}
+      stops={leftStops}
+      currentLang={currentLang}
+      dayForDivider={dayDivider}
+      showMinutes={showMinutes || 0}
+      withoutRouteColumn={withoutRouteColumn}
+    />
+  ));
   const headers = (columns, stops) => {
     let withStopCode = false;
-    stops.forEach(s => {
+    stops.forEach((s) => {
       if (s.settings?.showStopNumber) {
         withStopCode = true;
       }
     });
 
     const hasRouteColumn = [];
-    stops.forEach(s => {
+    stops.forEach((s) => {
       if (s.settings && s.settings.showRouteColumn !== undefined) {
         hasRouteColumn.push(s.settings.showRouteColumn);
       } else {
@@ -227,91 +258,91 @@ const MonitorRowContainer: FC<IProps> = ({
     return (
       <div
         className={cx(
-          'grid-headers',
+          "grid-headers",
           `rows${isTighten ? tighten[0] : columns}`,
           {
             tightened: isTighten,
             portrait: !isLandscape,
-            'two-cols': withTwoColumns,
-          },
+            "two-cols": withTwoColumns,
+          }
         )}
       >
         <div
           className={cx(
-            'grid-row',
-            { 'with-stop-code': withStopCode },
-            { 'without-route-column': withoutRouteColumn },
+            "grid-row",
+            { "with-stop-code": withStopCode },
+            { "without-route-column": withoutRouteColumn }
           )}
         >
           {!withoutRouteColumn && (
-            <div className={cx('grid-header', 'line')}>
-              {t('lineId', { lng: currentLang })}
+            <div className={cx("grid-header", "line")}>
+              {t("lineId", { lng: currentLang })}
             </div>
           )}
-          <div className={cx('grid-header', 'destination')}>
-            {t('destination', { lng: currentLang })}
+          <div className={cx("grid-header", "destination")}>
+            {t("destination", { lng: currentLang })}
           </div>
           {withStopCode && (
-            <div className={cx('grid-header', 'platform-code')}>
-              {t('platform-or-stop', { lng: currentLang })}
+            <div className={cx("grid-header", "platform-code")}>
+              {t("platform-or-stop", { lng: currentLang })}
             </div>
           )}
-          <div className={cx('grid-header', 'time')}>
-            {t('departureTime', { lng: currentLang })}
+          <div className={cx("grid-header", "time")}>
+            {t("departureTime", { lng: currentLang })}
           </div>
         </div>
       </div>
     );
   };
 
-  const closedStopIndex = closedStopViews.findIndex(s => s.viewId === viewId);
+  const closedStopIndex = closedStopViews.findIndex((s) => s.viewId === viewId);
   const isClosedStopOnLeft =
     closedStopIndex !== -1 &&
-    closedStopViews[closedStopIndex].column === 'left';
+    closedStopViews[closedStopIndex].column === "left";
   const isClosedStopOnRight =
     closedStopIndex !== -1 &&
-    closedStopViews[closedStopIndex].column === 'right';
+    closedStopViews[closedStopIndex].column === "right";
 
   const noKnownDeparturesLeft =
     !departuresLeft.length &&
-    !leftStops.every(s => s.settings?.allRoutesHidden);
+    !leftStops.every((s) => s.settings?.allRoutesHidden);
   const noKnownDeparturesRight =
     !departuresRight.length &&
-    !rightStops.every(s => s.settings?.allRoutesHidden);
+    !rightStops.every((s) => s.settings?.allRoutesHidden);
 
   return (
     <div
-      className={cx('monitor-container', {
+      className={cx("monitor-container", {
         preview: preview,
         portrait: !isLandscape,
-        'two-cols': withTwoColumns,
+        "two-cols": withTwoColumns,
         tightened: isTighten,
       })}
     >
       <div
-        className={cx('grid', {
+        className={cx("grid", {
           portrait: !isLandscape,
-          'two-cols': withTwoColumns,
+          "two-cols": withTwoColumns,
         })}
       >
         {headers(leftColumnCount, leftStops)}
         {isTighten && departuresLeft.length > 0 && (
           <div
-            className={cx('grid-rows portrait tightened', `rows${tighten[0]}`)}
+            className={cx("grid-rows portrait tightened", `rows${tighten[0]}`)}
           >
             {leftColumn.slice(0, tighten[0])}
           </div>
         )}
         <div
           className={cx(
-            'grid-rows',
+            "grid-rows",
             `rows${isTighten ? tighten[1] : leftColumnCount}`,
             {
               portrait: !isLandscape,
-              'two-cols': withTwoColumns,
+              "two-cols": withTwoColumns,
               tightened: isTighten,
-              'no-departures': isClosedStopOnLeft || noKnownDeparturesLeft,
-            },
+              "no-departures": isClosedStopOnLeft || noKnownDeparturesLeft,
+            }
           )}
         >
           {!isClosedStopOnLeft && !noKnownDeparturesLeft ? (
@@ -319,25 +350,25 @@ const MonitorRowContainer: FC<IProps> = ({
           ) : (
             <div className="no-departures-text-container">
               <div
-                className={cx('no-departures-text', {
-                  'closed-stop': isClosedStopOnLeft,
+                className={cx("no-departures-text", {
+                  "closed-stop": isClosedStopOnLeft,
                 })}
               >
                 {isClosedStopOnLeft
-                  ? t('closedStopWithRange', {
+                  ? t("closedStopWithRange", {
                       lng: currentLang,
                       name: closedStopViews[closedStopIndex].name,
                       code: closedStopViews[closedStopIndex].code,
                       startTime: formattedDateTimeFromSeconds(
                         closedStopViews[closedStopIndex].startTime,
-                        DATE_FORMAT,
+                        DATE_FORMAT
                       ),
                       endTime: formattedDateTimeFromSeconds(
                         closedStopViews[closedStopIndex].endTime,
-                        DATE_FORMAT,
+                        DATE_FORMAT
                       ),
                     })
-                  : t('no-departures', { lng: currentLang })}
+                  : t("no-departures", { lng: currentLang })}
               </div>
             </div>
           )}
@@ -348,15 +379,15 @@ const MonitorRowContainer: FC<IProps> = ({
         <>
           <div className="divider" />
           {true && (
-            <div className={cx('grid', { 'two-cols': withTwoColumns })}>
+            <div className={cx("grid", { "two-cols": withTwoColumns })}>
               {headers(
                 rightColumnCount,
-                isMultiDisplay ? rightStops : leftStops,
+                isMultiDisplay ? rightStops : leftStops
               )}
               <div
-                className={cx('grid-rows', `rows${rightColumnCount}`, {
-                  'two-cols': withTwoColumns,
-                  'no-departures':
+                className={cx("grid-rows", `rows${rightColumnCount}`, {
+                  "two-cols": withTwoColumns,
+                  "no-departures":
                     isClosedStopOnRight || noKnownDeparturesRight,
                 })}
               >
@@ -364,25 +395,25 @@ const MonitorRowContainer: FC<IProps> = ({
                   <>
                     <div className="no-departures-text-container">
                       <div
-                        className={cx('no-departures-text', {
-                          'closed-stop': isClosedStopOnRight,
+                        className={cx("no-departures-text", {
+                          "closed-stop": isClosedStopOnRight,
                         })}
                       >
                         {isClosedStopOnRight
-                          ? t('closedStopWithRange', {
+                          ? t("closedStopWithRange", {
                               lng: currentLang,
                               name: closedStopViews[closedStopIndex].name,
                               code: closedStopViews[closedStopIndex].code,
                               startTime: formattedDateTimeFromSeconds(
                                 closedStopViews[closedStopIndex].startTime,
-                                DATE_FORMAT,
+                                DATE_FORMAT
                               ),
                               endTime: formattedDateTimeFromSeconds(
                                 closedStopViews[closedStopIndex].endTime,
-                                DATE_FORMAT,
+                                DATE_FORMAT
                               ),
                             })
-                          : t('no-departures', { lng: currentLang })}
+                          : t("no-departures", { lng: currentLang })}
                       </div>
                     </div>
                     {alertComponent && <div className="alert-padding"></div>}


### PR DESCRIPTION
- The date separator showing change of date was not drawn properly when using a screen with two columns.
- This was due to the index of the separator being calculated only for a slice containing left side departures.

- Tested that this change does not affect other behavior such as when using a multidisplay with the columns containing departures for different stops.