### PR TITLE
AB#134 Fixes a bug where screens were saved under different ids

### DIFF
--- a/src/ui/MonitorRow.tsx
+++ b/src/ui/MonitorRow.tsx
@@ -17,7 +17,9 @@ export interface IStop {
   gtfsId: string;
   code: string;
   platformCode: string;
-  parentStation: any;
+  parentStation: {
+    gtfsId: string;
+  };
 }
 interface ITrip {
   tripHeadsign: string;

--- a/src/ui/StopCardRow.tsx
+++ b/src/ui/StopCardRow.tsx
@@ -189,9 +189,7 @@ const StopCardRow: FC<IProps> = ({
                 'shortName.length',
               ),
               hiddenRoutes: [],
-              parentStation: stop.parentStation
-                ? stop.parentStation.gtfsId
-                : undefined,
+              parentStation: stop.parentStation || null
             };
           }),
         undefined,

--- a/src/ui/TrainDataFetcher.tsx
+++ b/src/ui/TrainDataFetcher.tsx
@@ -88,8 +88,8 @@ const TrainDataFetcher: FC<IProps> = ({
   const shortCodes = stopAndRoutes
     .map(stop => {
       return {
-        gtfsId: stop.parentStation,
-        shortCode: stop?.shortCode || stop.parentStation.split(':')[1],
+        gtfsId: stop.parentStation.gtfsId,
+        shortCode: stop?.shortCode || stop.parentStation.gtfsId.split(':')[1],
       };
     })
     .filter(s => s);

--- a/src/ui/TrainDataPreparer.tsx
+++ b/src/ui/TrainDataPreparer.tsx
@@ -26,7 +26,9 @@ const createLineIdsArray = (data, hiddenRoutes) => {
             if (!filteredHiddenRoutes.includes(stringifyPattern(pattern))) {
               lineIds.push({
                 gtfsId: stop.gtfsId,
-                parentStation: station.gtfsId,
+                parentStation: {
+                  gtfsId: station.gtfsId
+                },
                 shortName: pattern.route.shortName,
                 stringifiedPattern: stringifyPattern(pattern),
               });
@@ -43,9 +45,7 @@ const createLineIdsArray = (data, hiddenRoutes) => {
           if (!filteredHiddenRoutes.includes(stringifyPattern(pattern))) {
             lineIds.push({
               gtfsId: stop.gtfsId,
-              parentStation: stop.parentStation
-                ? stop.parentStation.gtfsId
-                : stop.gtfsId,
+              parentStation: stop.parentStation || null,
               shortName: pattern.route.shortName,
               stringifiedPattern: stringifyPattern(pattern),
             });

--- a/src/util/Interfaces.ts
+++ b/src/util/Interfaces.ts
@@ -12,7 +12,9 @@ export interface IStop {
   settings?: ISettings;
   mode?: string;
   routes?: Array<any>;
-  parentStation?: string;
+  parentStation?: {
+    gtfsId: string;
+  };
 }
 export interface IStopInfoPlus extends IStop {
   cardId?: number;
@@ -141,7 +143,9 @@ export interface ICard {
   gtfsId: string;
   shortCode: string;
   source: string;
-  parentStation: string;
+  parentStation: {
+    gtfsId: string;
+  };
   hiddenRoutes: any;
 }
 export interface ICardInfo {


### PR DESCRIPTION
- When a screen containing a stop that has a parent stop was created and then edited it was saved twice with different identifiers even with no changes made
- The ID hash is created based on the card javascript object
  - The object was mutated due to inconsistent parentStation attribute shape, leading to different hash
  - By fixing the attribute to be of consistent shape, the card objects are now identical and the hash stays the same