### PR TITLE
Rename variables from multiDisplay to doubleView

### DIFF
--- a/src/ui/Monitor.tsx
+++ b/src/ui/Monitor.tsx
@@ -56,7 +56,7 @@ const Monitor: FC<IProps> = ({
     getWindowDimensions(),
   );
   const {
-    isMultiDisplay,
+    isDoubleView,
     fontSizeDivider,
     tightenedFontSizeDivider,
     previewFontSize,
@@ -161,7 +161,7 @@ const Monitor: FC<IProps> = ({
     >
       {!isPreview && <MonitorOverlay show={showOverlay} />}
       <MonitorTitlebar
-        isMultiDisplay={isMultiDisplay}
+        isDoubleView={isDoubleView}
         isLandscape={isLandscapeByLayout}
         preview={isPreview}
         view={view}

--- a/src/ui/MonitorRowContainer.tsx
+++ b/src/ui/MonitorRowContainer.tsx
@@ -79,8 +79,8 @@ const formatSingleColumnData = (
   return { rows, date, departuresIndex };
 };
 
-// Processess rows for a monitor containing a single stop display
-const formatSingleDisplayData = (
+// Processess rows for a monitor containing a single stop view
+const formatSingleViewData = (
   departures: IDeparture[],
   leftColumnSize: number,
   rightColumnSize: number,
@@ -102,8 +102,8 @@ const formatSingleDisplayData = (
   return { leftRows, rightRows };
 };
 
-// Processes rows for a multi display monitor (where right side has dedicated departures)
-const formatMultiDisplayData = (
+// Processes rows for a double view monitor (where right side has dedicated departures)
+const formatDoubleViewData = (
   departuresLeft: IDeparture[],
   departuresRight: IDeparture[],
   leftColumnSize: number,
@@ -145,7 +145,7 @@ const MonitorRowContainer: FC<IProps> = ({
 }) => {
   const [t] = useTranslation();
   const DATE_FORMAT = 'dd.MM.yyyy HH:mm';
-  const { leftColumnCount, rightColumnCount, isMultiDisplay, tighten } =
+  const { leftColumnCount, rightColumnCount, isDoubleView, tighten } =
     getLayout(layout);
 
   const isTighten = tighten !== undefined;
@@ -163,16 +163,15 @@ const MonitorRowContainer: FC<IProps> = ({
   if (alertComponent && layout < 12) {
     leftColumnCountWithAlerts -= alertRowSpan;
   }
-
-  const { leftRows, rightRows } = isMultiDisplay
-    ? formatMultiDisplayData(
+  const { leftRows, rightRows } = isDoubleView
+    ? formatDoubleViewData(
         departuresLeft,
         departuresRight,
         leftColumnCountWithAlerts,
         rightColumnCount,
         currentLang,
       )
-    : formatSingleDisplayData(
+    : formatSingleViewData(
         departuresLeft,
         leftColumnCountWithAlerts,
         rightColumnCount,
@@ -373,10 +372,7 @@ const MonitorRowContainer: FC<IProps> = ({
           <div className="divider" />
           {true && (
             <div className={cx('grid', { 'two-cols': withTwoColumns })}>
-              {headers(
-                rightColumnCount,
-                isMultiDisplay ? rightStops : leftStops,
-              )}
+              {headers(rightColumnCount, isDoubleView ? rightStops : leftStops)}
               <div
                 className={cx('grid-rows', `rows${rightColumnCount}`, {
                   'two-cols': withTwoColumns,

--- a/src/ui/MonitorTitleBar.tsx
+++ b/src/ui/MonitorTitleBar.tsx
@@ -10,7 +10,7 @@ import cx from 'classnames';
 
 interface IProps {
   preview: boolean;
-  isMultiDisplay?: boolean;
+  isDoubleView?: boolean;
   isLandscape?: boolean;
   view: IView;
   currentLang: string;
@@ -19,7 +19,7 @@ interface IProps {
 const MonitorTitlebar: FC<IProps> = ({
   view,
   preview,
-  isMultiDisplay = false,
+  isDoubleView: isDoubleView = false,
   isLandscape = false,
   currentLang,
 }) => {
@@ -32,7 +32,7 @@ const MonitorTitlebar: FC<IProps> = ({
       ? view.stops[0].coords[1]
       : view.columns.left.stops[0]?.lon;
 
-  const showWeather = !isMultiDisplay && isLandscape && lat && lon;
+  const showWeather = !isDoubleView && isLandscape && lat && lon;
 
   let temperature;
   let weatherIconString;
@@ -84,10 +84,10 @@ const MonitorTitlebar: FC<IProps> = ({
     <Titlebar
       isPreview={preview}
       isLandscape={isLandscape}
-      isMultiDisplay={isMultiDisplay}
+      isDoubleView={isDoubleView}
     >
       <Logo isPreview={preview} isLandscape={isLandscape} forMonitor={true} />
-      {!isMultiDisplay && (
+      {!isDoubleView && (
         <div
           className={cx('title-text', {
             preview: preview,
@@ -97,7 +97,7 @@ const MonitorTitlebar: FC<IProps> = ({
           {view.title[currentLang]}
         </div>
       )}
-      {isMultiDisplay && (
+      {isDoubleView && (
         <div className="multi-display-titles">
           <div className={cx('left-title', { preview: preview })}>
             {view.columns.left.title[currentLang]}

--- a/src/ui/MonitorTitleBar.tsx
+++ b/src/ui/MonitorTitleBar.tsx
@@ -19,7 +19,7 @@ interface IProps {
 const MonitorTitlebar: FC<IProps> = ({
   view,
   preview,
-  isDoubleView: isDoubleView = false,
+  isDoubleView = false,
   isLandscape = false,
   currentLang,
 }) => {

--- a/src/ui/StopCardListContainer.tsx
+++ b/src/ui/StopCardListContainer.tsx
@@ -216,8 +216,8 @@ const StopCardListContainer: FC<IProps> = ({
   const updateLayout = (cardId: number, value: number) => {
     const cardIndex = stopCardList.findIndex(card => card.id === cardId);
     if (
-      getLayout(stopCardList[cardIndex].layout).isMultiDisplay &&
-      !getLayout(+value).isMultiDisplay
+      getLayout(stopCardList[cardIndex].layout).isDoubleView &&
+      !getLayout(+value).isDoubleView
     ) {
       stopCardList[cardIndex].columns.left.stops = stopCardList[
         cardIndex
@@ -346,8 +346,8 @@ const StopCardListContainer: FC<IProps> = ({
       if (ismap) {
         return false;
       }
-      const isMultiDisplay = getLayout(stopCard.layout).isMultiDisplay;
-      return !isMultiDisplay
+      const isDoubleView = getLayout(stopCard.layout).isDoubleView;
+      return !isDoubleView
         ? stopCard.columns.left.stops.length === 0
         : stopCard.columns.left.stops.length === 0 ||
             stopCard.columns.right.stops.length === 0;

--- a/src/ui/StopListContainer.tsx
+++ b/src/ui/StopListContainer.tsx
@@ -46,7 +46,7 @@ const StopListContainer: FC<Props> = ({
   setStops,
 }) => {
   const [t] = useTranslation();
-  const showStopTitles = getLayout(card.layout).isMultiDisplay;
+  const showStopTitles = getLayout(card.layout).isDoubleView;
   const leftItems = card.columns.left.stops;
   const rightItems = card.columns.right.stops;
   return (

--- a/src/ui/StopRow.tsx
+++ b/src/ui/StopRow.tsx
@@ -89,7 +89,7 @@ const StopRow: FC<IProps> = ({
   const isDefaultSettings =
     isEqual(defaultSettings, stop.settings) || !stop.settings;
 
-  const moveBetweenColumns = getLayout(stop.layout).isMultiDisplay;
+  const moveBetweenColumns = getLayout(stop.layout).isDoubleView;
   const alternateIcon = config.modeIcons.postfix;
   return (
     <div className="stop-row-container">
@@ -154,7 +154,7 @@ const StopRow: FC<IProps> = ({
       >
         <Icon img="delete" color={config.colors.primary} />
       </div>
-      {getLayout(stop.layout).isMultiDisplay && (
+      {getLayout(stop.layout).isDoubleView && (
         <div
           className="stop-row-move icon"
           tabIndex={0}

--- a/src/ui/StopViewTitleEditor.tsx
+++ b/src/ui/StopViewTitleEditor.tsx
@@ -29,7 +29,7 @@ const StopViewTitleEditor: FC<IProps> = ({
 }) => {
   const { index, layout, id, title } = card;
   const [t] = useTranslation();
-  const { isMultiDisplay } = getLayout(layout);
+  const { isDoubleView } = getLayout(layout);
 
   const layoutTitle = t('layout-double');
   const onChange = title => {
@@ -41,10 +41,10 @@ const StopViewTitleEditor: FC<IProps> = ({
   return (
     <div className="stop-title">
       <p className="description">
-        {isMultiDisplay ? t('layout') : titleDescription}
+        {isDoubleView ? t('layout') : titleDescription}
       </p>
       <div className="stop-title-input-container">
-        {!isMultiDisplay && (
+        {!isDoubleView && (
           <InputWithEditIcon
             onChange={onChange}
             id={inputID}
@@ -58,7 +58,7 @@ const StopViewTitleEditor: FC<IProps> = ({
             })} ${t(`language-name-${lang}`)}`}
           />
         )}
-        {isMultiDisplay && (
+        {isDoubleView && (
           <input
             className={cx('monitor-input', 'double')}
             id={inputID}

--- a/src/ui/Titlebar.scss
+++ b/src/ui/Titlebar.scss
@@ -12,7 +12,7 @@ $preview-container-height: 365px;
   height: 15vh;
   margin: 0 2%;
 
-  &.multiDisplay { /* stylelint-disable-line */
+  &.doubleView { /* stylelint-disable-line */
     grid-template-columns: 14vw 1fr 14vw;
   }
 
@@ -75,7 +75,7 @@ $preview-container-height: 365px;
     height: 55px;
     grid-template-columns: calc(0.14 * #{$preview-container-width}) auto calc(0.073 * #{$preview-container-width}) calc(0.14 * #{$preview-container-width});
 
-    &.multiDisplay { /* stylelint-disable-line */
+    &.doubleView { /* stylelint-disable-line */
       grid-template-columns: calc(0.14 * #{$preview-container-width}) auto calc(0.14 * #{$preview-container-width});
     }
 

--- a/src/ui/Titlebar.tsx
+++ b/src/ui/Titlebar.tsx
@@ -3,14 +3,14 @@ import cx from 'classnames';
 export interface ITitlebarProps {
   readonly isPreview?: boolean;
   readonly isLandscape?: boolean;
-  readonly isMultiDisplay?: boolean;
+  readonly isDoubleView?: boolean;
   readonly children?: React.ReactNode;
 }
 
 const Titlebar: FC<ITitlebarProps> = ({
   isPreview,
   isLandscape,
-  isMultiDisplay,
+  isDoubleView,
   children,
 }) => {
   return (
@@ -18,7 +18,7 @@ const Titlebar: FC<ITitlebarProps> = ({
       className={cx('title-bar', {
         preview: isPreview,
         portrait: !isLandscape,
-        multiDisplay: isMultiDisplay,
+        doubleView: isDoubleView,
       })}
     >
       {children}

--- a/src/util/getResources.ts
+++ b/src/util/getResources.ts
@@ -1,7 +1,7 @@
 interface ILayout {
   leftColumnCount: number;
   rightColumnCount: number;
-  isMultiDisplay?: boolean;
+  isDoubleView?: boolean;
   isPortrait?: boolean;
   tighten?: Array<number>;
   alertSpan?: number;
@@ -65,28 +65,28 @@ export const getLayout = (layout: number): ILayout => {
       return {
         leftColumnCount: 4,
         rightColumnCount: 4,
-        isMultiDisplay: true,
+        isDoubleView: true,
         alertSpan: 1,
       };
     case 10:
       return {
         leftColumnCount: 8,
         rightColumnCount: 8,
-        isMultiDisplay: true,
+        isDoubleView: true,
         alertSpan: 2,
       };
     case 11:
       return {
         leftColumnCount: 12,
         rightColumnCount: 12,
-        isMultiDisplay: true,
+        isDoubleView: true,
         alertSpan: 3,
       };
     case 12:
       return {
         leftColumnCount: 8,
         rightColumnCount: 0,
-        isMultiDisplay: false,
+        isDoubleView: false,
         isPortrait: true,
         alertSpan: 1,
         fontSizeDivider: 15,
@@ -96,7 +96,7 @@ export const getLayout = (layout: number): ILayout => {
       return {
         leftColumnCount: 12,
         rightColumnCount: 0,
-        isMultiDisplay: false,
+        isDoubleView: false,
         isPortrait: true,
         alertSpan: 1,
         fontSizeDivider: 18,
@@ -106,7 +106,7 @@ export const getLayout = (layout: number): ILayout => {
       return {
         leftColumnCount: 16,
         rightColumnCount: 0,
-        isMultiDisplay: false,
+        isDoubleView: false,
         isPortrait: true,
         alertSpan: 1,
         fontSizeDivider: 18,
@@ -116,7 +116,7 @@ export const getLayout = (layout: number): ILayout => {
       return {
         leftColumnCount: 24,
         rightColumnCount: 0,
-        isMultiDisplay: false,
+        isDoubleView: false,
         isPortrait: true,
         alertSpan: 1,
         fontSizeDivider: 26,
@@ -126,7 +126,7 @@ export const getLayout = (layout: number): ILayout => {
       return {
         leftColumnCount: 10,
         rightColumnCount: 0,
-        isMultiDisplay: false,
+        isDoubleView: false,
         isPortrait: true,
         tighten: [4, 6],
         alertSpan: 1,
@@ -138,7 +138,7 @@ export const getLayout = (layout: number): ILayout => {
       return {
         leftColumnCount: 18,
         rightColumnCount: 0,
-        isMultiDisplay: false,
+        isDoubleView: false,
         isPortrait: true,
         tighten: [6, 12],
         alertSpan: 1,


### PR DESCRIPTION
- Multi display refers to the carousel display but it is incorrectly used in code to refer to the double view mode (separate views on left and right side)