### PR TITLE
Fix mqtt crashing with bad feed id

### DIFF
--- a/src/util/mqttUtils.ts
+++ b/src/util/mqttUtils.ts
@@ -25,6 +25,9 @@ export const startMqtt = (routes, setState, setClient, topicRef, cancelRef) => {
   }
 
   const feed = routes[0]?.feedId;
+  if (!feed || !settings[feed]) {
+    return Promise.resolve(null);
+  }
   const client = mqtt.connect(settings[feed].mqtt);
   setState({
     client: client,


### PR DESCRIPTION
- This is mainly a problem in dev environments with bad data, but now the mqtt won't be started with invalid feedids.